### PR TITLE
Add confirmation and minor safeguards for unavailable slots

### DIFF
--- a/src/modules/EmployeeManager.js
+++ b/src/modules/EmployeeManager.js
@@ -310,6 +310,27 @@ export const EmployeeManager = {
                 return;
             }
 
+            const getSlotLabel = (timeValue, slotIndex, isEnd = false) => {
+                if (typeof timeValue === 'number') {
+                    const idx = isEnd ? timeValue + 1 : timeValue;
+                    return SLOTS[idx]?.label || '';
+                }
+
+                if (typeof slotIndex === 'number') {
+                    const idx = isEnd ? slotIndex + 1 : slotIndex;
+                    if (SLOTS[idx]?.label) return SLOTS[idx].label;
+                }
+
+                if (typeof timeValue === 'string') {
+                    const normalized = timeValue.trim().substring(0, 5);
+                    const padded = normalized.length === 4 ? '0' + normalized : normalized;
+                    const match = SLOTS.find(s => s.label === padded);
+                    if (match) return match.label;
+                }
+
+                return '';
+            };
+
             DAYS.forEach((day, dayIndex) => {
                 const dayAvailability = emp.availability[dayIndex] || [];
                 const dayRow = create("div", {
@@ -325,26 +346,22 @@ export const EmployeeManager = {
                     slotsStack.appendChild(create("span", { className: "muted", style: { fontSize:"12px", paddingTop:"8px" }, textContent: "Día libre / Full-time" }));
                 } else {
                     dayAvailability.forEach((slot, slotIndex) => {
+                        const startValue = getSlotLabel(slot.start, slot.startSlot, false);
+                        const endValue = getSlotLabel(slot.end, slot.endSlot, true);
+
                         const slotRow = create("div", { className: "row", style: { justifyContent: "space-between", width: "100%" } });
                         const timeRow = create("div", { className: "row" });
 
                         const startSel = create("select", { className: "select availability-start" });
                         startSel.appendChild(create("option", { value:"", textContent:"--" }));
-                        SLOTS.forEach(s => {
-                            // Compare using substring to handle potential HH:MM:SS formats
-                            const val = slot.start ? String(slot.start).trim().substring(0, 5) : "";
-                            const isSelected = val === s.label;
-                            startSel.appendChild(create("option", { value:s.label, textContent:s.label, selected: isSelected }));
-                        });
+                        SLOTS.forEach(s => startSel.appendChild(create("option", { value:s.label, textContent:s.label })));
+                        if (startValue) startSel.value = startValue;
                         startSel.onchange = (e) => { slot.start = e.target.value || null; };
 
                         const endSel = create("select", { className: "select availability-end" });
                         endSel.appendChild(create("option", { value:"", textContent:"--" }));
-                        SLOTS.forEach(s => {
-                            const val = slot.end ? String(slot.end).trim().substring(0, 5) : "";
-                            const isSelected = val === s.label;
-                            endSel.appendChild(create("option", { value:s.label, textContent:s.label, selected: isSelected }));
-                        });
+                        SLOTS.forEach(s => endSel.appendChild(create("option", { value:s.label, textContent:s.label })));
+                        if (endValue) endSel.value = endValue;
                         endSel.onchange = (e) => { slot.end = e.target.value || null; };
 
                         timeRow.appendChild(startSel);

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1623,6 +1623,10 @@ export const ScheduleManager = {
     },
 
     handleSlotClick(shift, slotIndex) {
+        const state = store.getState();
+        const emp = shift.employeeId ? state.employees.find(e => e.id === shift.employeeId) : null;
+        const dayIndex = typeof state.activeDay === 'number' ? state.activeDay : 0;
+
         const tempShift = { ...shift };
         let modified = false;
 
@@ -1641,7 +1645,12 @@ export const ScheduleManager = {
         }
 
         if (modified) {
-            // Should check availability here...
+            const isUnavailable = emp && isSlotUnavailable(emp, slotIndex, state.activeWeek, dayIndex);
+            if (isUnavailable) {
+                const confirmMessage = 'Esta celda está marcada como no disponible para este empleado. ¿Querés continuar de todos modos?';
+                if (!confirm(confirmMessage)) return;
+            }
+
             this.commitChange(() => {
                 shift.startSlot = tempShift.startSlot;
                 shift.endSlot = tempShift.endSlot;

--- a/src/utils/rules.js
+++ b/src/utils/rules.js
@@ -1,4 +1,4 @@
-import { SLOTS } from '../config.js';
+import { SLOTS, MAX_SLOT_FOR_MINOR } from '../config.js';
 import { toISODateString, getMonday } from '../utils/date.js';
 import { store, getActiveSchedule } from '../store/Store.js';
 
@@ -173,14 +173,34 @@ export function calculateConsecutiveWorkDays(employeeId, weekId, dayIndex) {
 export function isSlotUnavailable(employee, slotIndex, weekId, dayIndex) {
     if (!employee) return false;
 
+    const minorCutoff = SLOTS.findIndex((s) => s.label === '20:00');
+    const minorRestrictionSlot = minorCutoff !== -1 ? minorCutoff : MAX_SLOT_FOR_MINOR + 1;
+
+    const normalizeSlotIndex = (timeValue, indexValue, isEnd = false) => {
+        if (typeof timeValue === 'number') return isEnd ? timeValue + 1 : timeValue;
+        if (typeof indexValue === 'number') return isEnd ? indexValue + 1 : indexValue;
+
+        if (typeof timeValue === 'string') {
+            const trimmed = timeValue.trim().substring(0, 5);
+            const padded = trimmed.length === 4 ? `0${trimmed}` : trimmed;
+            const idx = timeToSlotIndex(padded);
+            if (idx !== -1) return idx;
+        }
+
+        return -1;
+    };
+
     const shiftDate = new Date(`${weekId}T12:00:00.000Z`);
     shiftDate.setUTCDate(shiftDate.getUTCDate() + dayIndex);
     const shiftDateString = toISODateString(shiftDate).slice(0, 10);
 
-    // 1. Sanctions (Blocking)
+    // 1. Underage restriction (night hours)
+    if (employee.isMinor && slotIndex >= minorRestrictionSlot) return true;
+
+    // 2. Sanctions (Blocking)
     if (isDateInSanctionPeriod(shiftDate, employee.sanctions)) return true;
 
-    // 2. Exceptions
+    // 3. Exceptions
     if (employee.exceptions && Array.isArray(employee.exceptions)) {
         const exception = employee.exceptions.find(ex => ex.date === shiftDateString);
         if (exception) {
@@ -188,34 +208,40 @@ export function isSlotUnavailable(employee, slotIndex, weekId, dayIndex) {
             if (!exception.start && !exception.end) return true;
 
             // Partial exception: Unavailable during this range
-            const exStart = timeToSlotIndex(exception.start);
-            const exEnd = timeToSlotIndex(exception.end);
+            const exStart = normalizeSlotIndex(exception.start, exception.startSlot);
+            const exEnd = normalizeSlotIndex(exception.end, exception.endSlot, true);
 
-            if (exStart !== -1 && exEnd !== -1) {
-                if (slotIndex >= exStart && slotIndex < exEnd) return true;
-            }
+            const startIdx = exStart === -1 ? 0 : exStart;
+            const endIdx = exEnd === -1 ? SLOTS.length : exEnd;
+
+            if (slotIndex >= startIdx && slotIndex < endIdx) return true;
         }
     }
 
-    // 3. Weekly Availability
+    // 4. Weekly Availability
     // If defined, slot must be inside at least one range to be AVAILABLE.
-    if (employee.availability && Array.isArray(employee.availability)) {
-        const daySlots = employee.availability[dayIndex];
-        if (daySlots && daySlots.length > 0) {
-            let isCovered = false;
-            for (const range of daySlots) {
-                const rStart = range.start ? timeToSlotIndex(range.start) : 0;
-                const rEnd = range.end ? timeToSlotIndex(range.end) : SLOTS.length; // Exclusive end
+    const rawAvailability = employee.availability || {};
+    const daySlots = Array.isArray(rawAvailability)
+        ? rawAvailability[dayIndex]
+        : rawAvailability?.[dayIndex] || rawAvailability?.[String(dayIndex)];
 
-                if (rStart !== -1 && rEnd !== -1) {
-                    if (slotIndex >= rStart && slotIndex < rEnd) {
-                        isCovered = true;
-                        break;
-                    }
-                }
+    if (daySlots && daySlots.length > 0) {
+        let isCovered = false;
+        for (const range of daySlots) {
+            const rStart = normalizeSlotIndex(range?.start, range?.startSlot);
+            const rEnd = normalizeSlotIndex(range?.end, range?.endSlot, true) ?? SLOTS.length;
+
+            if (rStart === -1 && rEnd === -1) continue;
+
+            const startIdx = rStart === -1 ? 0 : rStart;
+            const endIdx = rEnd === -1 ? SLOTS.length : rEnd;
+
+            if (slotIndex >= startIdx && slotIndex < endIdx) {
+                isCovered = true;
+                break;
             }
-            if (!isCovered) return true; // Unavailable if not covered
         }
+        if (!isCovered) return true; // Unavailable if not covered
     }
 
     return false;

--- a/style.css
+++ b/style.css
@@ -17,9 +17,12 @@
     --c-descarga:#14b8a6;      /* teal */
     --c-active-border: #9333ea; /* purple-600 */
 
-    --c-warning: #9a3412; /* amber-800 */
-    --c-warning-bg: #fffbeb; /* amber-50 */
-    --c-warning-border: #fcd34d; /* amber-300 */
+  --c-warning: #9a3412; /* amber-800 */
+  --c-warning-bg: #fffbeb; /* amber-50 */
+  --c-warning-border: #fcd34d; /* amber-300 */
+  --c-danger: #ef4444; /* rojo para conflictos */
+  --c-danger-soft: rgba(239, 68, 68, 0.16);
+  --c-danger-strong: rgba(239, 68, 68, 0.3);
   }
   *{box-sizing:border-box}
   html, body {
@@ -164,6 +167,10 @@ body.dark-mode {
   --ink: #ffffff;
   --muted: #99aab5;
   --border: #3a3e44;
+
+  --c-danger: #f87171;
+  --c-danger-soft: rgba(248, 113, 113, 0.22);
+  --c-danger-strong: rgba(248, 113, 113, 0.36);
 
   --c-warning: #fde68a; /* amber-200 */
   --c-warning-bg: #451a03; /* amber-950 */
@@ -1218,12 +1225,36 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
     100% { transform: rotate(360deg); }
 }
 .unavailable-slot {
-    background: repeating-linear-gradient(
-        45deg,
-        rgba(255, 0, 0, 0.1),
-        rgba(255, 0, 0, 0.1) 5px,
-        rgba(255, 0, 0, 0.2) 5px,
-        rgba(255, 0, 0, 0.2) 10px
-    ) !important;
+    background-image: repeating-linear-gradient(
+        135deg,
+        color-mix(in srgb, var(--c-danger) 8%, transparent),
+        color-mix(in srgb, var(--c-danger) 8%, transparent) 5px,
+        transparent 5px,
+        transparent 14px
+    );
+    background-color: transparent !important;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--c-danger) 12%, transparent);
+    border-radius: 4px;
     cursor: not-allowed;
 }
+
+.slot.assigned.unavailable-slot::after {
+    content: "";
+    position: absolute;
+    inset: 3px;
+    border-radius: 3px;
+    background-image: repeating-linear-gradient(
+        135deg,
+        color-mix(in srgb, var(--c-danger) 12%, transparent),
+        color-mix(in srgb, var(--c-danger) 12%, transparent) 6px,
+        transparent 6px,
+        transparent 16px
+    );
+    opacity: 0.4;
+    mix-blend-mode: multiply;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.slot.assigned.unavailable-slot .label,
+.slot.assigned.unavailable-slot { position: relative; z-index: 1; }


### PR DESCRIPTION
## Summary
- prompt managers before resizing shifts into unavailable slots while keeping warnings visible beneath assigned colors
- flag nighttime half-hours for underage employees and highlight all conflicts more subtly in both themes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb53a2014832da3d8c43e9d1bd7cf)