### PR TITLE
Wrap employee export selection in dropdown menu

### DIFF
--- a/manager.html
+++ b/manager.html
@@ -8,6 +8,7 @@
 <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/12.2.1/firebase-firestore-compat.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -56,31 +57,170 @@
     <div id="view-employees" class="wrap" style="display:none; max-width: none; padding: 0 16px;">
         <!-- Empleados -->
         <section class="card">
-            <div class="card-h"><strong>Empleados</strong></div>
+            <div class="card-h card-h-controls">
+              <div class="stack" style="gap:4px;">
+                <strong>Empleados</strong>
+                <span class="muted mini-label">Gestiona la base de colaboradores, disponibilidad y etiquetas sin salir del planificador.</span>
+              </div>
+              <div class="row" style="gap:8px; align-items:center;">
+                <span class="muted mini-label">Vista diseñada para escritorio</span>
+                <span class="pill pill-neutral" id="stat-filtered-employees">--</span>
+              </div>
+            </div>
             <div class="card-c stack">
-                <div class="row">
-                    <input id="inpName" class="input" placeholder="Nombre y apellido" style="flex:1">
-                    <input id="inpDni" class="input" placeholder="DNI" style="flex:1">
-                    <input id="inpMail" class="input" placeholder="Mail" style="flex:1">
-                    <input id="inpCell" class="input" placeholder="Celular" style="flex:1">
-                    <button id="btnAddEmp" class="btn">Añadir</button>
-                </div>
-                <div class="hr"></div>
-                <div class="row">
-                  <label class="btn secondary" style="cursor:pointer;">
-                    Importar desde Excel
-                    <input id="fileImportExcel" class="file" type="file" accept=".xlsx, .xls" style="display:none">
-                  </label>
-                </div>
-                <div class="hr"></div>
-                <div class="row">
-                    <span class="muted" style="font-size:12px">Filtrar empleados por estrella:</span>
-                    <select id="empFilter" class="select"></select>
+                <div class="employee-overview-grid">
+                  <div class="employee-stat-card">
+                    <div class="muted mini-label">Total de empleados</div>
+                    <div class="stat-value" id="stat-total-employees">--</div>
+                    <div class="muted mini-label">Incluye todos los perfiles cargados</div>
+                  </div>
+                  <div class="employee-stat-card">
+                    <div class="muted mini-label">All Star</div>
+                    <div class="stat-value" id="stat-all-stars">--</div>
+                    <div class="mini-pill b-blue">Con insignia destacada</div>
+                  </div>
+                  <div class="employee-stat-card">
+                    <div class="muted mini-label">Menores</div>
+                    <div class="stat-value" id="stat-minors">--</div>
+                    <div class="mini-pill b-minor">Controlá sus límites</div>
+                  </div>
+                  <div class="employee-stat-card">
+                    <div class="muted mini-label">Disponibilidad cargada</div>
+                    <div class="stat-value" id="stat-availability">--</div>
+                    <div class="mini-pill b-green">Con restricciones definidas</div>
+                  </div>
+                  <div class="employee-stat-card">
+                    <div class="muted mini-label">Con licencias o sanciones</div>
+                    <div class="stat-value" id="stat-sanctions">--</div>
+                    <div class="mini-pill b-warning">Seguimiento activo</div>
+                  </div>
                 </div>
 
-                <div class="hr"></div>
-                <div class="row">
-                    <input id="empSearch" class="input" placeholder="Buscar empleado..." style="flex:1">
+                <div class="employee-controls-grid">
+                  <div class="control-card">
+                    <div class="control-card-head">Alta rápida</div>
+                    <div class="control-card-body stack">
+                      <div class="row employee-form-row">
+                          <input id="inpName" class="input" placeholder="Nombre y apellido" style="flex:1">
+                          <input id="inpDni" class="input" placeholder="DNI" style="flex:1">
+                          <input id="inpMail" class="input" placeholder="Mail" style="flex:1">
+                          <input id="inpCell" class="input" placeholder="Celular" style="flex:1">
+                          <button id="btnAddEmp" class="btn">Añadir</button>
+                      </div>
+                      <div class="muted mini-label">La columna "Nombre para planilla" se edita dentro de la fila del empleado.</div>
+                    </div>
+                  </div>
+
+                  <div class="control-card">
+                    <div class="control-card-head">Filtros y búsqueda</div>
+                    <div class="control-card-body stack" style="gap:10px;">
+                      <div class="row" style="gap:8px;">
+                        <input id="empSearch" class="input" placeholder="Buscar por nombre o contacto" style="flex:2">
+                        <select id="empFilter" class="select" style="flex:1"></select>
+                      </div>
+                      <div class="row filter-badges" style="gap:10px;">
+                        <label class="pill pill-toggle"><input id="filterAllStarOnly" type="checkbox"> Solo All Star</label>
+                        <label class="pill pill-toggle"><input id="filterMinorOnly" type="checkbox"> Solo menores</label>
+                        <label class="pill pill-toggle"><input id="filterSanctionsOnly" type="checkbox"> Con sanciones</label>
+                        <label class="pill pill-toggle"><input id="filterAvailabilityOnly" type="checkbox"> Con disponibilidad</label>
+                      </div>
+                      <div class="row" style="gap:8px; align-items:center;">
+                        <div class="row" style="gap:6px; flex:1; align-items:center;">
+                          <span class="muted mini-label">Ordenar por</span>
+                          <select id="empSort" class="select" style="flex:1;">
+                            <option value="name">Nombre (A-Z)</option>
+                            <option value="priority">Prioridad</option>
+                            <option value="stars">Cantidad de estrellas</option>
+                          </select>
+                        </div>
+                        <button id="btn-clear-emp-filters" class="btn secondary" style="white-space:nowrap;">Limpiar filtros</button>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="control-card">
+                    <div class="control-card-head">Utilidades</div>
+                    <div class="control-card-body stack utilities-body" style="gap:12px;">
+                      <div class="row" style="align-items:center; gap:10px; flex-wrap:wrap;">
+                        <label class="btn secondary" style="cursor:pointer;">
+                          Importar desde Excel
+                          <input id="fileImportExcel" class="file" type="file" accept=".xlsx, .xls" style="display:none">
+                        </label>
+                        <div class="stack" style="gap:4px; min-width:220px;">
+                          <span class="muted mini-label">Exportar datos</span>
+                          <span class="muted" style="font-size:12px;">Elegí columnas y descargá en Excel o PDF.</span>
+                        </div>
+                      </div>
+                      <div class="row export-controls" style="gap:10px; flex-wrap:wrap; align-items:center;">
+                        <div class="dropdown export-dropdown">
+                          <button id="btn-export-fields-menu" class="btn secondary">Datos a exportar ▾</button>
+                          <div id="export-fields-dropdown" class="dropdown-content export-dropdown-content">
+                            <div class="stack" style="padding:12px; gap:10px;">
+                              <div class="export-fields-grid">
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="name" checked>
+                                  <span>Nombre completo</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="displayName" checked>
+                                  <span>Nombre para planilla</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="dni" checked>
+                                  <span>DNI</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="mail" checked>
+                                  <span>Mail</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="celular" checked>
+                                  <span>Celular</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="stars" checked>
+                                  <span>Roles/Estrellas</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="allStar" checked>
+                                  <span>All Star</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="minor" checked>
+                                  <span>Menor</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="availability" checked>
+                                  <span>Disponibilidad (resumen)</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="exceptions">
+                                  <span>Excepciones</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="sanctions">
+                                  <span>Licencias / sanciones</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="priority">
+                                  <span>Prioridad</span>
+                                </label>
+                              </div>
+                              <div class="row" style="gap:8px; flex-wrap:wrap;">
+                                <button id="btn-select-all-fields" class="btn secondary">Seleccionar todo</button>
+                                <button id="btn-clear-fields" class="btn secondary">Limpiar selección</button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <span class="muted mini-label" style="flex:1; min-width:220px;">Elegí los datos desde el menú y generá el reporte con el formato que prefieras.</span>
+                        <div class="row" style="gap:8px;">
+                          <button id="btn-export-employees-excel" class="btn">Exportar a Excel</button>
+                          <button id="btn-export-employees-pdf" class="btn secondary">Exportar a PDF</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
 
                 <div id="empList" class="stack"></div>

--- a/manager.html
+++ b/manager.html
@@ -97,7 +97,7 @@
                 </div>
 
                 <div class="employee-controls-grid">
-                  <div class="control-card">
+                  <div class="control-card utilities-card">
                     <div class="control-card-head">Alta rápida</div>
                     <div class="control-card-body stack">
                       <div class="row employee-form-row">

--- a/src/modules/EmployeeManager.js
+++ b/src/modules/EmployeeManager.js
@@ -4,9 +4,27 @@ import { DataManager } from '../services/DataManager.js';
 import { getActiveSchedule } from '../store/Store.js';
 import { ROLES } from '../config.js';
 
+const EXPORT_FIELD_CONFIG = {
+    name: { label: 'Nombre completo', getter: (e) => e.name || '' },
+    displayName: { label: 'Nombre para planilla', getter: (e) => e.displayName || '' },
+    dni: { label: 'DNI', getter: (e) => e.dni || '' },
+    mail: { label: 'Mail', getter: (e) => e.mail || '' },
+    celular: { label: 'Celular', getter: (e) => e.celular || '' },
+    stars: { label: 'Roles/Estrellas', getter: (e) => (e.stars || []).join(', ') || 'Sin roles' },
+    allStar: { label: 'All Star', getter: (e) => e.isAllStar ? 'Sí' : 'No' },
+    minor: { label: 'Menor', getter: (e) => e.isMinor ? 'Sí' : 'No' },
+    availability: { label: 'Disponibilidad (resumen)', getter: (e, ctx) => ctx.getAvailabilitySummary(e) },
+    exceptions: { label: 'Excepciones', getter: (e) => `${(e.exceptions || []).length}` },
+    sanctions: { label: 'Licencias / sanciones', getter: (e) => `${(e.sanctions || []).length}` },
+    priority: { label: 'Prioridad', getter: (e, ctx) => ctx.priorityLabel(e.priority) }
+};
+
 export const EmployeeManager = {
     init() {
+        this.roleSignature = '';
+        this.populateRoleFilter();
         this.bindEvents();
+        store.subscribe((state) => this.handleStoreUpdate(state));
     },
 
     bindEvents() {
@@ -14,6 +32,78 @@ export const EmployeeManager = {
         el("#inpName")?.addEventListener("keydown", (ev) => { if(ev.key==="Enter") this.addEmployee(); });
         el("#empFilter")?.addEventListener("change", () => this.renderList());
         el("#empSearch")?.addEventListener("input", () => this.renderList());
+        el("#empSort")?.addEventListener("change", () => this.renderList());
+        el("#btn-clear-emp-filters")?.addEventListener("click", () => this.resetFilters());
+        el("#fileImportExcel")?.addEventListener("change", (ev) => this.importFromExcel(ev));
+        el("#btn-export-employees-excel")?.addEventListener("click", () => this.exportSelected("excel"));
+        el("#btn-export-employees-pdf")?.addEventListener("click", () => this.exportSelected("pdf"));
+        el("#btn-select-all-fields")?.addEventListener("click", () => this.toggleExportFields(true));
+        el("#btn-clear-fields")?.addEventListener("click", () => this.toggleExportFields(false));
+        this.bindExportDropdown();
+
+        ["#filterAllStarOnly", "#filterMinorOnly", "#filterSanctionsOnly", "#filterAvailabilityOnly"].forEach(sel => {
+            el(sel)?.addEventListener("change", () => this.renderList());
+        });
+    },
+
+    bindExportDropdown() {
+        const btn = el('#btn-export-fields-menu');
+        const dropdown = el('#export-fields-dropdown');
+        if (!btn || !dropdown) return;
+
+        const hide = () => dropdown.classList.remove('show');
+
+        btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const isOpen = dropdown.classList.contains('show');
+            document.querySelectorAll('.dropdown-content').forEach(d => { if (d !== dropdown) d.classList.remove('show'); });
+            dropdown.classList.toggle('show', !isOpen);
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!dropdown.contains(e.target) && e.target !== btn) hide();
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') hide();
+        });
+    },
+
+    handleStoreUpdate(state) {
+        const roles = (state?.roles && state.roles.length) ? state.roles : ROLES;
+        const signature = roles.map(r => `${r.key}-${r.color || ''}-${r.darkText ? '1' : '0'}`).join('|');
+        if (signature !== this.roleSignature) {
+            this.roleSignature = signature;
+            this.populateRoleFilter(roles);
+        }
+    },
+
+    populateRoleFilter(rolesList = []) {
+        const empFilter = el("#empFilter");
+        if (!empFilter) return;
+
+        const roles = rolesList.length ? rolesList : ((store.getState().roles && store.getState().roles.length) ? store.getState().roles : ROLES);
+
+        empFilter.innerHTML = "";
+        empFilter.appendChild(create("option", { value: "", textContent: "Todos" }));
+        roles.forEach(role => empFilter.appendChild(create("option", { value: role.key, textContent: role.key })));
+    },
+
+    resetFilters() {
+        const search = el("#empSearch");
+        const star = el("#empFilter");
+        const sort = el("#empSort");
+
+        if (search) search.value = "";
+        if (star) star.value = "";
+        if (sort) sort.value = "name";
+
+        ["#filterAllStarOnly", "#filterMinorOnly", "#filterSanctionsOnly", "#filterAvailabilityOnly"].forEach(sel => {
+            const checkbox = el(sel);
+            if (checkbox) checkbox.checked = false;
+        });
+
+        this.renderList();
     },
 
     addEmployee() {
@@ -55,32 +145,99 @@ export const EmployeeManager = {
         DataManager.saveState();
     },
 
+    importFromExcel(event) {
+        const file = event?.target?.files?.[0];
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            try {
+                const data = new Uint8Array(e.target.result);
+                const workbook = XLSX.read(data, { type: 'array' });
+                const sheetName = workbook.SheetNames[0];
+                const worksheet = workbook.Sheets[sheetName];
+                const rows = XLSX.utils.sheet_to_json(worksheet, { header: 1 });
+
+                const employees = [...(store.getState().employees || [])];
+                let importedCount = 0;
+
+                rows.slice(1).forEach(row => {
+                    const name = row[0];
+                    if (name && String(name).trim()) {
+                        const normalized = String(name).trim();
+                        const aliasParts = normalized.split(',');
+                        const displayName = (aliasParts.length > 1) ? aliasParts[1].trim() : normalized.split(' ')[0];
+                        const id = crypto.randomUUID();
+                        const base = {
+                            id,
+                            name: normalized,
+                            displayName: displayName,
+                            dni: '',
+                            mail: '',
+                            celular: '',
+                            stars: [],
+                            isMinor: false,
+                            isAllStar: false,
+                            priority: 'medium',
+                            availability: { "0": [], "1": [], "2": [], "3": [], "4": [], "5": [], "6": [] },
+                            exceptions: [],
+                            sanctions: [],
+                        };
+                        employees.push(base);
+                        importedCount++;
+                    }
+                });
+
+                store.setState({ employees });
+                DataManager.saveState();
+                alert(`Se importaron ${importedCount} empleados.`);
+            } catch (err) {
+                console.error(err);
+                alert('Error al importar empleados.');
+            }
+        };
+        reader.readAsArrayBuffer(file);
+        event.target.value = "";
+    },
+
     renderList() {
         const state = store.getState();
         const empList = el("#empList");
         if (!empList) return;
 
         const starFilter = el("#empFilter")?.value;
-        const searchFilter = el("#empSearch")?.value.toLowerCase();
+        const searchFilter = (el("#empSearch")?.value || "").toLowerCase();
+        const sortMode = el("#empSort")?.value || "name";
+
+        const filters = {
+            allStarOnly: el("#filterAllStarOnly")?.checked,
+            minorOnly: el("#filterMinorOnly")?.checked,
+            sanctionsOnly: el("#filterSanctionsOnly")?.checked,
+            availabilityOnly: el("#filterAvailabilityOnly")?.checked,
+        };
 
         const employees = Array.isArray(state.employees) ? state.employees : [];
 
         const filtered = employees
             .filter(e => e && typeof e === 'object') // Filter out null/undefined entries
             .slice()
-            .sort((a, b) => {
-                const nameA = a.name || '';
-                const nameB = b.name || '';
-                return nameA.localeCompare(nameB);
-            })
+            .sort((a, b) => this.sortEmployees(a, b, sortMode))
             .filter(e => {
                 const name = e.name || '';
-                const nameMatch = name.toLowerCase().includes(searchFilter);
+                const contact = `${e.mail || ''} ${e.celular || ''} ${e.dni || ''}`;
+                const nameMatch = `${name} ${contact}`.toLowerCase().includes(searchFilter);
                 const starMatch = !starFilter || (e.stars || []).includes(starFilter);
-                return nameMatch && starMatch;
+                const allStarMatch = !filters.allStarOnly || e.isAllStar;
+                const minorMatch = !filters.minorOnly || e.isMinor;
+                const sanctionMatch = !filters.sanctionsOnly || ((e.sanctions || []).length > 0);
+                const availabilityMatch = !filters.availabilityOnly || this.hasAvailability(e);
+
+                return nameMatch && starMatch && allStarMatch && minorMatch && sanctionMatch && availabilityMatch;
             });
 
         clear(empList);
+
+        this.updateStats(employees, filtered);
 
         if(filtered.length===0){
             empList.appendChild(create("div", { className: "muted", textContent: "Agregá tu primer empleado 👇" }));
@@ -89,7 +246,7 @@ export const EmployeeManager = {
 
         const table = create("table", { className: "emp-table-new" });
         const thead = create("thead");
-        thead.innerHTML = "<tr><th>Nombre</th><th>DNI/Mail/Cel</th><th>Estrellas</th><th>Acciones</th></tr>";
+        thead.innerHTML = "<tr><th>Nombre</th><th>Contacto</th><th>Estrellas</th><th>Acciones</th></tr>";
         table.appendChild(thead);
 
         const tbody = create("tbody");
@@ -122,22 +279,38 @@ export const EmployeeManager = {
                 container.appendChild(prioritySelect);
                 nameCell.appendChild(container);
             } else {
-                nameCell.textContent = e.name;
-                if (e.isAllStar) {
-                    nameCell.appendChild(create("span", { className: "badge b-all-star", textContent: "★", title: "All Star", style: { marginLeft: "8px" } }));
-                }
-                if (e.isMinor) {
-                    nameCell.appendChild(create("span", { className: "badge b-minor", textContent: "M", title: "Menor de edad", style: { marginLeft: "8px" } }));
-                }
+                const titleRow = create("div", { className: "employee-name-row" });
+                titleRow.appendChild(create("strong", { textContent: e.name || 'Sin nombre' }));
+
+                const flags = create("div", { className: "employee-flags" });
+                if (e.isAllStar) flags.appendChild(create("span", { className: "badge b-all-star", textContent: "All Star" }));
+                if (e.isMinor) flags.appendChild(create("span", { className: "badge b-minor", textContent: "Menor" }));
+                const sanctionsCount = (e.sanctions || []).length;
+                if (sanctionsCount > 0) flags.appendChild(create("span", { className: "badge b-empaque", textContent: `${sanctionsCount} sanc.` }));
+                titleRow.appendChild(flags);
+                nameCell.appendChild(titleRow);
+
+                nameCell.appendChild(create("div", { className: "muted", style: { fontSize: "12px" }, textContent: e.displayName || "Sin alias de planilla" }));
+
+                const meta = create("div", { className: "employee-meta" });
+                const exceptions = (e.exceptions || []).length;
+                if (exceptions > 0) meta.appendChild(create("span", { className: "pill pill-neutral", textContent: `${exceptions} excepción${exceptions === 1 ? '' : 'es'}` }));
+                const starCount = (e.stars || []).length;
+                meta.appendChild(create("span", { className: "pill pill-neutral", textContent: starCount > 0 ? `${starCount} rol${starCount === 1 ? '' : 'es'}` : "Sin roles" }));
+                nameCell.appendChild(meta);
             }
             row.appendChild(nameCell);
 
-            // DNI Cell
-            const dniCell = create("td");
+            // Contact Cell
+            const contactCell = create("td");
             if (!isEditing) {
-                dniCell.innerHTML = `<div>${e.dni || '-'}</div><div class="muted" style="font-size:12px;">${e.mail || '-'}</div><div class="muted" style="font-size:12px;">${e.celular || '-'}</div>`;
+                const contactStack = create("div", { className: "employee-contact" });
+                contactStack.appendChild(create("span", { textContent: e.dni ? `DNI: ${e.dni}` : "DNI no cargado" }));
+                contactStack.appendChild(create("span", { className: e.mail ? "" : "muted", textContent: e.mail || "Mail no cargado" }));
+                contactStack.appendChild(create("span", { className: e.celular ? "" : "muted", textContent: e.celular || "Celular no cargado" }));
+                contactCell.appendChild(contactStack);
             }
-            row.appendChild(dniCell);
+            row.appendChild(contactCell);
 
             // Stars Cell
             const starsCell = create("td");
@@ -166,10 +339,12 @@ export const EmployeeManager = {
             } else {
                 actionsCell.appendChild(create("button", { className: "btn secondary", textContent: "Editar", onClick: () => { store.setState({ editingEmployeeId: e.id, activeDetailEmployeeId: null }); this.renderList(); } }));
                 actionsCell.appendChild(create("button", { className: "btn secondary", textContent: "Estrellas", onClick: () => this.toggleDetail(e.id, 'stars') }));
+                actionsCell.appendChild(create("button", { className: "btn secondary", textContent: "Disponibilidad", onClick: () => this.toggleDetail(e.id, 'availability') }));
+                actionsCell.appendChild(create("button", { className: "btn secondary", textContent: "Excepciones", onClick: () => this.toggleDetail(e.id, 'exceptions') }));
 
                 // Dropdown logic
                 const dropdown = create("div", { className: "dropdown" });
-                const ddBtn = create("button", { className: "btn secondary", textContent: "Gestion de empleado ▾", onClick: (ev) => {
+                const ddBtn = create("button", { className: "btn secondary", textContent: "Gestión de empleado ▾", onClick: (ev) => {
                     ev.stopPropagation();
                     const content = ddBtn.nextElementSibling;
                     document.querySelectorAll('.dropdown-content').forEach(d => { if (d !== content) d.classList.remove('show'); });
@@ -178,17 +353,14 @@ export const EmployeeManager = {
                 dropdown.appendChild(ddBtn);
 
                 const ddContent = create("div", { className: "dropdown-content" });
-                ddContent.appendChild(create("button", { className: "dropdown-item", textContent: "Disponibilidad", onClick: () => this.toggleDetail(e.id, 'availability') }));
-                ddContent.appendChild(create("button", { className: "dropdown-item", textContent: "Excepciones", onClick: () => this.toggleDetail(e.id, 'exceptions') }));
                 ddContent.appendChild(create("button", { className: "dropdown-item", textContent: "Sanciones y licencias", onClick: () => this.toggleDetail(e.id, 'sanctions') }));
                 ddContent.appendChild(create("button", { className: "dropdown-item", textContent: e.isAllStar ? "Quitar All Star" : "Hacer All Star", onClick: () => { this.toggleIsAllStar(e.id); ddContent.classList.remove('show'); } }));
                 ddContent.appendChild(create("button", { className: "dropdown-item", textContent: e.isMinor ? "Quitar Menor" : "Hacer Menor", onClick: () => { this.toggleIsMinor(e.id); ddContent.classList.remove('show'); } }));
                 ddContent.appendChild(create("button", { className: "dropdown-item", textContent: "💬 Enviar WhatsApp", onClick: () => { this.sendWhatsApp(e.id); ddContent.classList.remove('show'); } }));
+                ddContent.appendChild(create("button", { className: "dropdown-item del", textContent: "Eliminar empleado", onClick: () => { this.removeEmployee(e.id); ddContent.classList.remove('show'); } }));
 
                 dropdown.appendChild(ddContent);
                 actionsCell.appendChild(dropdown);
-
-                actionsCell.appendChild(create("button", { className: "btn secondary del", textContent: "Eliminar", onClick: () => this.removeEmployee(e.id) }));
             }
             row.appendChild(actionsCell);
             tbody.appendChild(row);
@@ -571,6 +743,161 @@ export const EmployeeManager = {
 
         panel.appendChild(stack);
         container.appendChild(panel);
+    },
+
+    sortEmployees(a, b, mode) {
+        const nameA = (a.name || '').toLowerCase();
+        const nameB = (b.name || '').toLowerCase();
+        const priorityOrder = { 'very-high': 1, 'high': 2, 'medium': 3, 'low': 4, 'very-low': 5 };
+
+        if (mode === 'priority') {
+            const pa = priorityOrder[a.priority] || priorityOrder['medium'];
+            const pb = priorityOrder[b.priority] || priorityOrder['medium'];
+            if (pa !== pb) return pa - pb;
+        } else if (mode === 'stars') {
+            const sa = (a.stars || []).length;
+            const sb = (b.stars || []).length;
+            if (sa !== sb) return sb - sa;
+        }
+
+        return nameA.localeCompare(nameB);
+    },
+
+    hasAvailability(emp) {
+        if (!emp || typeof emp !== 'object') return false;
+        const availability = emp.availability || {};
+        return Object.values(availability).some(day => Array.isArray(day) && day.length > 0);
+    },
+
+    getAvailabilitySummary(emp) {
+        const daysWithRules = Object.values(emp.availability || {}).filter(day => Array.isArray(day) && day.length > 0).length;
+        const exceptionsCount = (emp.exceptions || []).length;
+
+        if (daysWithRules === 0 && exceptionsCount === 0) return "Sin restricciones cargadas";
+
+        const parts = [];
+        if (daysWithRules > 0) parts.push(`${daysWithRules} día${daysWithRules === 1 ? '' : 's'} con disponibilidad`);
+        if (exceptionsCount > 0) parts.push(`${exceptionsCount} excepción${exceptionsCount === 1 ? '' : 'es'}`);
+        return parts.join(" · ");
+    },
+
+    getSelectedExportFields() {
+        return Array.from(document.querySelectorAll('.export-field input[type="checkbox"]'))
+            .filter(cb => cb.checked)
+            .map(cb => cb.value)
+            .filter(Boolean);
+    },
+
+    toggleExportFields(checked) {
+        document.querySelectorAll('.export-field input[type="checkbox"]').forEach(cb => { cb.checked = checked; });
+    },
+
+    exportSelected(format = 'excel') {
+        const selectedFields = this.getSelectedExportFields();
+        if (!selectedFields.length) {
+            alert('Seleccioná al menos un dato para exportar.');
+            return;
+        }
+
+        const employees = Array.isArray(store.getState().employees) ? store.getState().employees : [];
+        if (!employees.length) {
+            alert('No hay empleados para exportar.');
+            return;
+        }
+
+        const rows = employees.map(emp => this.buildExportRow(emp, selectedFields));
+        if (format === 'pdf') this.exportToPdf(rows);
+        else this.exportToExcel(rows);
+    },
+
+    buildExportRow(emp, fields) {
+        const row = {};
+        fields.forEach(f => {
+            const config = EXPORT_FIELD_CONFIG[f];
+            if (config) row[config.label] = config.getter(emp, this);
+        });
+        return row;
+    },
+
+    exportToExcel(rows) {
+        if (!rows.length || typeof XLSX === 'undefined') return;
+        const worksheet = XLSX.utils.json_to_sheet(rows);
+        const workbook = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(workbook, worksheet, "Empleados");
+        XLSX.writeFile(workbook, 'empleados.xlsx');
+    },
+
+    exportToPdf(rows) {
+        if (!rows.length) return;
+        const jspdfLib = window.jspdf;
+        if (!jspdfLib || !jspdfLib.jsPDF) {
+            alert('No se pudo cargar el exportador PDF.');
+            return;
+        }
+        const { jsPDF } = jspdfLib;
+        const doc = new jsPDF({ orientation: 'landscape' });
+        let y = 16;
+
+        doc.setFontSize(16);
+        doc.text('Empleados', 10, y);
+        y += 6;
+        doc.setFontSize(11);
+
+        rows.forEach((row, idx) => {
+            if (y > 190) { doc.addPage(); y = 16; }
+            const name = row['Nombre completo'] || 'Sin nombre';
+            doc.text(name, 10, y);
+            y += 6;
+
+            Object.entries(row).forEach(([label, value]) => {
+                if (label === 'Nombre completo') return;
+                const line = `${label}: ${value || '-'}`;
+                const wrapped = doc.splitTextToSize(line, 270);
+                wrapped.forEach(part => {
+                    doc.text(part, 10, y);
+                    y += 5;
+                });
+            });
+
+            if (idx < rows.length - 1) {
+                doc.setDrawColor(200);
+                doc.line(10, y, 280, y);
+                y += 6;
+            }
+        });
+
+        doc.save('empleados.pdf');
+    },
+
+    priorityLabel(value) {
+        const labels = {
+            'very-high': 'Muy alta',
+            'high': 'Alta',
+            'medium': 'Media',
+            'low': 'Baja',
+            'very-low': 'Muy baja'
+        };
+        return labels[value] || 'Sin prioridad';
+    },
+
+    updateStats(allEmployees, filteredEmployees) {
+        const setText = (selector, value) => {
+            const elRef = el(selector);
+            if (elRef) elRef.textContent = value;
+        };
+
+        const total = allEmployees.length;
+        const allStars = allEmployees.filter(e => e.isAllStar).length;
+        const minors = allEmployees.filter(e => e.isMinor).length;
+        const withAvailability = allEmployees.filter(e => this.hasAvailability(e)).length;
+        const withSanctions = allEmployees.filter(e => (e.sanctions || []).length > 0).length;
+
+        setText("#stat-total-employees", total);
+        setText("#stat-all-stars", allStars);
+        setText("#stat-minors", minors);
+        setText("#stat-availability", withAvailability);
+        setText("#stat-sanctions", withSanctions);
+        setText("#stat-filtered-employees", `Mostrando ${filteredEmployees.length} de ${total}`);
     },
 
     toggleIsAllStar(empId) {

--- a/style.css
+++ b/style.css
@@ -305,6 +305,15 @@ body.dark-mode .request-type.availability { background: rgba(14, 165, 233, 0.16)
 body.dark-mode .pill { background: #1f2933; }
 body.dark-mode .copy-btn { border-color: #4b5563; color: var(--ink); }
 body.dark-mode .copy-btn:hover { background: #374151; }
+body.dark-mode .employee-stat-card,
+body.dark-mode .control-card { background: var(--card); border-color: var(--border); }
+body.dark-mode .control-card-head { background: #111827; }
+body.dark-mode .mini-pill { background: rgba(255,255,255,0.08); color: var(--ink); }
+body.dark-mode .pill-toggle { background: #1f2937; border-color: #374151; }
+body.dark-mode .pill.pill-neutral { border-color: #4b5563; }
+body.dark-mode .b-blue { background: rgba(99, 102, 241, 0.18); color: #c7d2fe; }
+body.dark-mode .b-green { background: rgba(34, 197, 94, 0.18); color: #bbf7d0; }
+body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a; }
 
 /* Employee Table */
 .emp-table-new {
@@ -329,6 +338,190 @@ body.dark-mode .copy-btn:hover { background: #374151; }
 .emp-table-new .actions-cell-new .btn {
   padding: 6px 10px;
   font-size: 13px;
+}
+
+/* Employee Workspace */
+.employee-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.employee-stat-card {
+  border: 1px solid var(--border);
+  background: var(--card);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 120px;
+}
+
+.stat-value {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.mini-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  width: fit-content;
+  color: var(--ink);
+  background: rgba(107, 114, 128, 0.12);
+}
+
+.b-blue { background: #e0e7ff; color: #1e3a8a; }
+.b-green { background: #dcfce7; color: #166534; }
+.b-warning { background: #fef3c7; color: #92400e; }
+
+
+.pill-neutral {
+  background: rgba(107, 114, 128, 0.12);
+  color: var(--ink);
+}
+
+.pill-toggle {
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+  align-items: center;
+  border: 1px solid var(--border);
+  background: var(--card);
+}
+
+.pill-toggle input {
+  margin: 0;
+}
+
+.utilities-body {
+  background: var(--bg);
+}
+
+.export-fields-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+}
+
+.export-field {
+  justify-content: flex-start;
+  padding: 8px 10px;
+}
+
+.export-controls {
+  align-items: center;
+}
+
+.export-dropdown { position: relative; }
+
+.export-dropdown-content {
+  left: 0;
+  right: auto;
+  min-width: 520px;
+  max-width: 720px;
+}
+
+.dropdown-content .del {
+  color: #c0392b;
+}
+
+.employee-controls-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 12px;
+}
+
+.control-card {
+  border: 1px solid var(--border);
+  background: var(--bg);
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+/* width balancing handled via grid auto-fit */
+
+.control-card-head {
+  padding: 12px;
+  background: var(--card);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+}
+
+.control-card-body {
+  padding: 12px;
+}
+
+.employee-form-row {
+  gap: 8px;
+}
+
+.filter-badges {
+  flex-wrap: wrap;
+}
+
+.filter-badges .pill {
+  border: 1px dashed var(--border);
+  background: var(--bg);
+}
+
+.emp-table-new .employee-name-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.employee-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.employee-meta {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.employee-contact {
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.employee-flags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.availability-note {
+  font-size: 13px;
+  color: var(--muted);
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.pill.pill-neutral {
+  border: 1px solid var(--border);
+}
+
+.emp-table-new .actions-cell-new {
+  width: 520px;
+}
+
+.employee-availability-cell {
+  min-width: 240px;
 }
 
 .employee-detail-cell {
@@ -1249,6 +1442,10 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
   .emp-table-new th, .emp-table-new td {
       padding: 8px;
       font-size: 13px;
+  }
+
+  .control-card.wide {
+      grid-column: span 1;
   }
 
   .emp-table-new .actions-cell-new {

--- a/style.css
+++ b/style.css
@@ -404,30 +404,32 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
 }
 
 .export-fields-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 8px;
 }
 
 .export-field {
   justify-content: flex-start;
   padding: 8px 10px;
+  width: 100%;
 }
 
 .export-controls {
   align-items: center;
 }
 
-.export-dropdown { position: relative; z-index: 3; }
+.export-dropdown { position: relative; z-index: 90; isolation: isolate; }
 
 .export-dropdown-content {
   left: 0;
   right: auto;
   top: calc(100% + 8px);
-  width: clamp(380px, 52vw, 680px);
-  max-height: 440px;
+  width: 260px;
+  max-height: 420px;
   overflow-y: auto;
-  box-shadow: 0 18px 40px rgba(0,0,0,0.25);
+  box-shadow: 0 18px 40px rgba(0,0,0,0.28);
+  z-index: 999;
 }
 
 .dropdown-content .del {

--- a/style.css
+++ b/style.css
@@ -418,13 +418,16 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   align-items: center;
 }
 
-.export-dropdown { position: relative; }
+.export-dropdown { position: relative; z-index: 3; }
 
 .export-dropdown-content {
   left: 0;
   right: auto;
-  min-width: 520px;
-  max-width: 720px;
+  top: calc(100% + 8px);
+  width: clamp(380px, 52vw, 680px);
+  max-height: 440px;
+  overflow-y: auto;
+  box-shadow: 0 18px 40px rgba(0,0,0,0.25);
 }
 
 .dropdown-content .del {
@@ -445,6 +448,10 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   display: flex;
   flex-direction: column;
   min-height: 100%;
+}
+
+.control-card.utilities-card {
+  overflow: visible;
 }
 
 /* width balancing handled via grid auto-fit */


### PR DESCRIPTION
## Summary
- move the employee export field checklist into a "Datos a exportar" dropdown to reduce space in utilidades
- wire the new dropdown toggle behavior and preserve select all/clear shortcuts alongside export actions
- style the export dropdown for desktop width while keeping the controls compact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f64f88d98832da963191ac0be9477)