### PR TITLE
Añadir flujo multi-local con selección de local

### DIFF
--- a/MIGRACION_MULTI_LOCAL.md
+++ b/MIGRACION_MULTI_LOCAL.md
@@ -1,0 +1,59 @@
+# Migración a modelo multi-local
+
+## Estructura objetivo
+```
+stores/{storeId}
+  employees/{employeeId}
+  solicitudes/{solicitudId}
+  schedules/{docId}   // se mantiene "main" para configuración
+  weeks/{weekId}
+  settings/{docId}
+users/{uid}
+```
+
+## Crear usuarios
+1. Crear `users/{uid}` para cada cuenta con:
+   - `displayName`: nombre visible.
+   - `allowedStores`: array de IDs de local autorizados.
+   - `defaultStore`: ID por defecto (opcional).
+   - `role`: `"manager"` o `"admin"`.
+
+Si el documento no existe, la app muestra *"Usuario sin permisos"* y bloquea el acceso.
+
+## Crear locales
+1. Crear documento en `stores/{storeId}` (puede estar vacío).
+2. Crear las subcolecciones según necesidad (`employees`, `schedules`, `weeks`, `solicitudes`).
+3. Para configuración principal crear `stores/{storeId}/schedules/main` con:
+   - `templates`, `projectedTickets`, `breaks`, `roles`, `rappiCode`.
+
+## Compatibilidad temporal
+- Los servicios primero buscan datos en `stores/{storeId}`.
+- Si no existen, caen a la estructura legacy global (`employees`, `schedules/main`, `weeks`, `solicitudes`).
+- Todo fallback está marcado con `// TODO MIGRACION MULTI-LOCAL` y centralizado en servicios.
+
+## Plan de migración manual rápida
+1. Seleccionar un `storeId` objetivo.
+2. Copiar `employees` globales a `stores/{storeId}/employees`.
+3. Copiar `schedules/main` a `stores/{storeId}/schedules/main`.
+4. Copiar `weeks/*` a `stores/{storeId}/weeks/*`.
+5. Copiar `solicitudes/*` a `stores/{storeId}/solicitudes/*`.
+6. Crear documentos `users/{uid}` con `allowedStores` que incluyan el store migrado.
+7. Validar acceso con la app y luego borrar colecciones legacy cuando ya no se usen.
+
+## Script de ayuda
+`node scripts/migrate_to_stores.js --store=<storeId> [--dry-run]`
+
+- Copia colecciones legacy (`employees`, `schedules/main`, `weeks`, `solicitudes`) a `stores/{storeId}`.
+- Por defecto corre en modo lectura y muestra el plan. Use `--execute` para escribir.
+- No borra datos existentes.
+
+## Reglas de seguridad
+El archivo `firestore.rules` contiene un borrador multi-local:
+- Solo usuarios autenticados.
+- Acceso a `stores/{storeId}` restringido a `users/{uid}.allowedStores`.
+- Actualización de solicitudes permitida solo a roles `manager/admin`.
+
+## Notas
+- Mantener idioma en UI.
+- Si se cambia el local activo, la app recarga el estado para ese store.
+- Los logs de consola indican cuando se usa compatibilidad legacy.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,20 +1,47 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /employees/{employeeId} {
-      allow read, write: if request.auth.token.role == 'manager';
-      allow read: if request.auth.token.role == 'employee' && request.auth.token.employeeId == employeeId;
+    function isSignedIn() {
+      return request.auth != null;
     }
 
-    match /shifts/{shiftId} {
-      allow read, write: if request.auth.token.role == 'manager';
-      allow read: if request.auth.token.role == 'employee' && resource.data.employeeId == request.auth.token.employeeId;
+    function userDoc() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid));
     }
 
-    match /requests/{requestId} {
-      allow read, write: if request.auth.token.role == 'manager';
-      allow create: if request.auth.token.role == 'employee' && request.resource.data.employeeId == request.auth.token.employeeId;
-      allow read, update: if request.auth.token.role == 'employee' && resource.data.employeeId == request.auth.token.employeeId;
+    function allowedStores() {
+      return isSignedIn() ? (userDoc().data.allowedStores || []) : [];
+    }
+
+    function userRole() {
+      return isSignedIn() ? (userDoc().data.role || '') : '';
+    }
+
+    function hasStoreAccess(storeId) {
+      return isSignedIn() && allowedStores().hasAny([storeId]);
+    }
+
+    match /users/{uid} {
+      allow read: if isSignedIn() && uid == request.auth.uid;
+      allow write: if false;
+    }
+
+    match /stores/{storeId}/employees/{employeeId} {
+      allow read, write: if hasStoreAccess(storeId) && userRole() in ['manager', 'admin'];
+    }
+
+    match /stores/{storeId}/schedules/{docId} {
+      allow read, write: if hasStoreAccess(storeId) && userRole() in ['manager', 'admin'];
+    }
+
+    match /stores/{storeId}/weeks/{weekId} {
+      allow read, write: if hasStoreAccess(storeId) && userRole() in ['manager', 'admin'];
+    }
+
+    match /stores/{storeId}/solicitudes/{reqId} {
+      allow read: if hasStoreAccess(storeId);
+      allow create: if hasStoreAccess(storeId);
+      allow update, delete: if hasStoreAccess(storeId) && userRole() in ['manager', 'admin'];
     }
   }
 }

--- a/login.js
+++ b/login.js
@@ -24,17 +24,22 @@ document.addEventListener('DOMContentLoaded', () => {
   auth.onAuthStateChanged(async (user) => {
     if (user) {
       try {
-        const idTokenResult = await user.getIdTokenResult();
-        const role = idTokenResult.claims.role;
+        const userDoc = await db.collection('users').doc(user.uid).get();
+        if (!userDoc.exists) {
+          alert('Usuario sin permisos');
+          await auth.signOut();
+          return;
+        }
+        const profile = userDoc.data();
+        const role = profile.role || (await user.getIdTokenResult())?.claims?.role;
 
-        if (role === 'manager') {
+        if (role === 'manager' || role === 'admin') {
           window.location.href = 'manager.html';
         } else if (role === 'employee') {
           window.location.href = 'portal/index.html';
         } else {
-          // If no role, sign out and show an error
-          console.error("User has no role claim.");
-          auth.signOut();
+          console.error("Usuario sin rol válido");
+          await auth.signOut();
         }
       } catch (error) {
         console.error("Error getting user token:", error);

--- a/scripts/migrate_to_stores.js
+++ b/scripts/migrate_to_stores.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+const admin = require('firebase-admin');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const storeArg = args.find(a => a.startsWith('--store='));
+const execute = args.includes('--execute');
+const dryRun = args.includes('--dry-run');
+
+if (!storeArg) {
+  console.error('Uso: node scripts/migrate_to_stores.js --store=<storeId> [--dry-run|--execute]');
+  process.exit(1);
+}
+
+const storeId = storeArg.split('=')[1];
+if (!storeId) {
+  console.error('Debe indicar --store=<storeId>');
+  process.exit(1);
+}
+
+const credentialPath = path.resolve(__dirname, '..', 'horarios-data-firebase-adminsdk-qg20g-a3c1b68991.json');
+admin.initializeApp({
+  credential: admin.credential.cert(require(credentialPath))
+});
+
+const db = admin.firestore();
+
+async function copyCollection(src, dest) {
+  const snap = await src.get();
+  console.log(`Encontrados ${snap.size} documentos en ${src.path}`);
+  if (snap.empty) return;
+  const batch = db.batch();
+  snap.docs.forEach(doc => {
+    const target = dest.doc(doc.id);
+    batch.set(target, doc.data(), { merge: true });
+  });
+  if (execute) {
+    await batch.commit();
+    console.log(`Copiados ${snap.size} documentos a ${dest.path}`);
+  } else {
+    console.log(`[DRY RUN] Se copiarían ${snap.size} documentos a ${dest.path}`);
+  }
+}
+
+async function run() {
+  console.log(`Migrando datos legacy a stores/${storeId}`);
+  if (dryRun && execute) {
+    console.warn('Seleccione solo uno: --dry-run o --execute');
+    process.exit(1);
+  }
+  if (!dryRun && !execute) {
+    console.log('Modo predeterminado: solo lectura (dry-run). Use --execute para escribir.');
+  }
+
+  const employeesSrc = db.collection('employees');
+  const employeesDest = db.collection('stores').doc(storeId).collection('employees');
+  const schedulesSrc = db.collection('schedules').doc('main');
+  const schedulesDest = db.collection('stores').doc(storeId).collection('schedules').doc('main');
+  const weeksSrc = db.collection('weeks');
+  const weeksDest = db.collection('stores').doc(storeId).collection('weeks');
+  const solicitudesSrc = db.collection('solicitudes');
+  const solicitudesDest = db.collection('stores').doc(storeId).collection('solicitudes');
+
+  await copyCollection(employeesSrc, employeesDest);
+  const schedulesSnap = await schedulesSrc.get();
+  if (schedulesSnap.exists) {
+    if (execute) {
+      await schedulesDest.set(schedulesSnap.data(), { merge: true });
+      console.log('Copiada configuración main a store.');
+    } else {
+      console.log('[DRY RUN] Se copiaría schedules/main a store.');
+    }
+  }
+  await copyCollection(weeksSrc, weeksDest);
+  await copyCollection(solicitudesSrc, solicitudesDest);
+
+  console.log('Migración finalizada.');
+}
+
+run().catch((err) => {
+  console.error('Error en migración:', err);
+  process.exit(1);
+});

--- a/src/app_main.js
+++ b/src/app_main.js
@@ -1,4 +1,6 @@
-import { DataManager, initFirebase } from './services/DataManager.js';
+import { DataManager } from './services/DataManager.js';
+import { initFirebase } from './services/firebase.js';
+import { SessionService } from './services/SessionService.js';
 import { store } from './store/Store.js';
 import { UIManager } from './modules/UIManager.js';
 import { EmployeeManager } from './modules/EmployeeManager.js';
@@ -13,6 +15,12 @@ import { el } from './utils/dom.js';
 async function init() {
     console.log("App Main: Starting Init");
     initFirebase();
+    try {
+        await SessionService.requireSession();
+    } catch (err) {
+        console.error('No se pudo iniciar sesión/seleccionar local', err);
+        return;
+    }
 
     // Bind global managers
     UIManager.init();
@@ -46,7 +54,15 @@ async function init() {
     });
 
     // Initial Load
-    await DataManager.loadState();
+    await DataManager.loadState(store.getState().activeStoreId);
+
+    document.addEventListener('store-changed', async (event) => {
+        const storeId = event.detail?.storeId;
+        if (!storeId) return;
+        store.setState({ isLoading: true });
+        await DataManager.loadState(storeId);
+        UIManager.showView(store.getState().activeView || 'schedule');
+    });
 
     // Force initial render (store subscribe might trigger on loadState but let's be sure)
     UIManager.showView('schedule');

--- a/src/modules/EmployeeManager.js
+++ b/src/modules/EmployeeManager.js
@@ -3,6 +3,7 @@ import { store } from '../store/Store.js';
 import { DataManager } from '../services/DataManager.js';
 import { getActiveSchedule } from '../store/Store.js';
 import { ROLES } from '../config.js';
+import { storeEmployeesRef, legacyEmployeesRef } from '../services/firestoreRefs.js';
 
 const EXPORT_FIELD_CONFIG = {
     name: { label: 'Nombre completo', getter: (e) => e.name || '' },
@@ -411,7 +412,9 @@ export const EmployeeManager = {
         store.setState({ employees: newEmployees });
 
         import('../services/DataManager.js').then(({getDb}) => {
-             getDb().collection('employees').doc(empId).delete().catch(console.error);
+             const storeId = store.getState().activeStoreId;
+             const ref = storeId ? storeEmployeesRef(storeId) : legacyEmployeesRef(); // TODO MIGRACION MULTI-LOCAL
+             ref.doc(empId).delete().catch(console.error);
         });
 
         DataManager.saveState();

--- a/src/modules/RequestsManager.js
+++ b/src/modules/RequestsManager.js
@@ -18,6 +18,7 @@
 import { el, create, clear } from '../utils/dom.js';
 import { getDb } from '../services/DataManager.js';
 import { store } from '../store/Store.js';
+import { storeSolicitudesRef, legacySolicitudesRef } from '../services/firestoreRefs.js';
 
 const MAX_REQUESTS = 200; // límite de carga para evitar traer toda la colección
 
@@ -45,6 +46,12 @@ export const RequestsManager = {
     },
     unsubscribe: null,
 
+    collectionForStore() {
+        const storeId = store.getState().activeStoreId;
+        if (!storeId) return legacySolicitudesRef(); // TODO MIGRACION MULTI-LOCAL
+        return storeSolicitudesRef(storeId);
+    },
+
     init() {
         this.cacheElements();
         this.bindFilters();
@@ -52,6 +59,16 @@ export const RequestsManager = {
 
         document.addEventListener('view-changed', (e) => {
             if (e.detail.view === 'requests') {
+                this.ensureListener();
+            }
+        });
+
+        document.addEventListener('store-changed', () => {
+            if (this.unsubscribe) {
+                this.unsubscribe();
+                this.unsubscribe = null;
+            }
+            if (store.getState().activeView === 'requests') {
                 this.ensureListener();
             }
         });
@@ -82,11 +99,20 @@ export const RequestsManager = {
         const db = getDb();
         if (!db) return;
 
+        const state = store.getState();
+        const storeId = state.activeStoreId;
+        if (!storeId) {
+            console.warn('Solicitudes: no hay local activo');
+            return;
+        }
+
         this.state.loading = true;
         this.render();
 
         // Consulta ordenada por fecha de creación desc y limitada.
-        this.unsubscribe = db.collection('solicitudes')
+        const collectionRef = this.collectionForStore();
+
+        this.unsubscribe = collectionRef
             .orderBy('fechaCreacion', 'desc')
             .limit(MAX_REQUESTS)
             .onSnapshot(
@@ -442,7 +468,7 @@ export const RequestsManager = {
         this.state.actionError = '';
         this.render();
         try {
-            await getDb().collection('solicitudes').doc(this.pendingActionId).update({ estado: 'aprobada', motivoRechazo: null });
+            await this.collectionForStore().doc(this.pendingActionId).update({ estado: 'aprobada', motivoRechazo: null });
             this.toggleModal(this.approveModal, false);
             this.pendingActionId = null;
         } catch (error) {
@@ -465,7 +491,7 @@ export const RequestsManager = {
         this.state.actionError = '';
         this.render();
         try {
-            await getDb().collection('solicitudes').doc(this.pendingActionId).update({
+            await this.collectionForStore().doc(this.pendingActionId).update({
                 estado: 'rechazada',
                 motivoRechazo: reason
             });
@@ -492,7 +518,7 @@ export const RequestsManager = {
         this.state.actionError = '';
         this.render();
         try {
-            await getDb().collection('solicitudes').doc(this.pendingActionId).delete();
+            await this.collectionForStore().doc(this.pendingActionId).delete();
             this.toggleModal(this.deleteModal, false);
             this.state.requests = this.state.requests.filter((r) => r.id !== this.pendingActionId);
             if (this.state.selectedId === this.pendingActionId) {

--- a/src/services/DataManager.js
+++ b/src/services/DataManager.js
@@ -1,24 +1,15 @@
 import { store, getActiveSchedule } from '../store/Store.js';
-import { firebaseConfig, ROLES, setRoles, DEFAULT_ROLES } from '../config.js';
-
-let firestore = null;
-
-export function initFirebase() {
-    if (typeof firebase === 'undefined') {
-        console.error("Firebase SDK not loaded.");
-        return null;
-    }
-    if (!firebase.apps.length) {
-        firebase.initializeApp(firebaseConfig);
-    }
-    firestore = firebase.firestore();
-    return firestore;
-}
-
-export function getDb() {
-    if (!firestore) return initFirebase();
-    return firestore;
-}
+import { ROLES, setRoles, DEFAULT_ROLES } from '../config.js';
+import { getDb, initFirebase } from './firebase.js';
+export { getDb } from './firebase.js';
+import {
+    legacyEmployeesRef,
+    legacySchedulesRef,
+    legacyWeeksRef,
+    storeEmployeesRef,
+    storeSchedulesRef,
+    storeWeeksRef
+} from './firestoreRefs.js';
 
 function getMonday(d) {
     d = new Date(d);
@@ -36,7 +27,7 @@ function toISODateString(date) {
 }
 
 export const DataManager = {
-    async loadState() {
+    async loadState(storeId) {
         console.log("DataManager: Loading state...");
         store.setState({ isLoading: true });
 
@@ -44,12 +35,18 @@ export const DataManager = {
             const db = getDb();
             if (!db) throw new Error("Firebase not initialized");
 
+            if (!storeId) throw new Error('Falta storeId activo');
+
+            const schedulesRef = storeSchedulesRef(storeId);
+            const employeesRef = storeEmployeesRef(storeId);
+            const weeksRef = storeWeeksRef(storeId);
+
             // 1. Load Main Doc (Settings, Templates, etc.)
-            const mainDocRef = db.collection("schedules").doc("main");
+            const mainDocRef = schedulesRef.doc("main");
             const mainDoc = await mainDocRef.get();
 
             // 2. Load Employees
-            const employeesSnapshot = await db.collection('employees').get();
+            const employeesSnapshot = await employeesRef.get();
             const employeesArray = [];
             employeesSnapshot.forEach(doc => {
                 employeesArray.push({ id: doc.id, ...doc.data() });
@@ -58,8 +55,19 @@ export const DataManager = {
             const currentState = store.getState();
             let newState = { ...currentState };
 
+            let data = null;
             if (mainDoc.exists) {
-                const data = mainDoc.data();
+                data = mainDoc.data();
+            } else {
+                // TODO MIGRACION MULTI-LOCAL: fallback a estructura legacy
+                console.warn('DataManager: usando schedules/main legacy');
+                const legacyMain = await legacySchedulesRef().doc('main').get();
+                if (legacyMain.exists) {
+                    data = legacyMain.data();
+                }
+            }
+
+            if (data) {
 
                 // Legacy employees handling
                 let legacyEmployees = [];
@@ -67,6 +75,9 @@ export const DataManager = {
                     legacyEmployees = Array.isArray(data.employees) ? data.employees : Object.values(data.employees);
                 }
 
+                if (!employeesArray.length && legacyEmployees.length) {
+                    console.warn('DataManager: empleados desde estructura legacy');
+                }
                 newState.employees = employeesArray.length > 0 ? employeesArray : legacyEmployees;
 
                 const loadedRoles = Array.isArray(data.roles) && data.roles.length > 0 ? data.roles : DEFAULT_ROLES;
@@ -121,7 +132,7 @@ export const DataManager = {
                 }
 
                 // --- SCHEDULE LOADING STRATEGY ---
-                const weekDocRef = db.collection("weeks").doc(newState.activeWeek);
+                const weekDocRef = weeksRef.doc(newState.activeWeek);
                 const weekDoc = await weekDocRef.get();
 
                 newState.schedules = {}; // Reset schedules cache
@@ -139,8 +150,14 @@ export const DataManager = {
                     if (legacySchedules[newState.activeWeek]) {
                         newState.schedules[newState.activeWeek] = legacySchedules[newState.activeWeek];
                     } else {
-                        // New week
-                        newState.schedules[newState.activeWeek] = {};
+                        // Intentar levantar semana de estructura legacy weeks
+                        const legacyWeekDoc = await legacyWeeksRef().doc(newState.activeWeek).get();
+                        if (legacyWeekDoc.exists) {
+                            newState.schedules[newState.activeWeek] = legacyWeekDoc.data();
+                        } else {
+                            // New week
+                            newState.schedules[newState.activeWeek] = {};
+                        }
                     }
                 }
             } else {
@@ -166,12 +183,20 @@ export const DataManager = {
     async saveState() {
         const db = getDb();
         const state = store.getState();
+        const storeId = state.activeStoreId;
+        if (!storeId) {
+            console.warn('Intento de guardar sin store activo');
+            return;
+        }
+        const schedulesRef = storeSchedulesRef(storeId);
+        const employeesRef = storeEmployeesRef(storeId);
+        const weeksRef = storeWeeksRef(storeId);
         const activeWeek = state.activeWeek;
         const currentSchedule = state.schedules[activeWeek];
 
         try {
             if (activeWeek && currentSchedule) {
-                await db.collection("weeks").doc(activeWeek).set(currentSchedule);
+                await weeksRef.doc(activeWeek).set(currentSchedule);
             }
 
             const mainData = {
@@ -183,12 +208,12 @@ export const DataManager = {
                 rappiCode: state.rappiCode,
                 roles: state.roles && state.roles.length ? state.roles : ROLES,
             };
-            await db.collection("schedules").doc("main").set(mainData, { merge: true });
+            await schedulesRef.doc("main").set(mainData, { merge: true });
 
             const batch = db.batch();
             let opCount = 0;
             state.employees.forEach(emp => {
-                const empRef = db.collection('employees').doc(emp.id);
+                const empRef = employeesRef.doc(emp.id);
                 batch.set(empRef, emp, { merge: true });
                 opCount++;
                 if (opCount >= 400) {
@@ -207,6 +232,12 @@ export const DataManager = {
     async loadWeek(weekId) {
         const db = getDb();
         const state = store.getState();
+        const storeId = state.activeStoreId;
+        if (!storeId) {
+            console.warn('Intento de cargar semana sin store activo');
+            return;
+        }
+        const weeksRef = storeWeeksRef(storeId);
 
         if (state.schedules[weekId]) {
             store.setState({ activeWeek: weekId });
@@ -215,19 +246,25 @@ export const DataManager = {
 
         store.setState({ isLoading: true });
         try {
-            const weekDoc = await db.collection("weeks").doc(weekId).get();
+            const weekDoc = await weeksRef.doc(weekId).get();
             let weekData = {};
 
             if (weekDoc.exists) {
                 weekData = weekDoc.data();
             } else {
-                 const mainDoc = await db.collection("schedules").doc("main").get();
+                 // TODO MIGRACION MULTI-LOCAL: fallback a estructura legacy
+                 const mainDoc = await legacySchedulesRef().doc("main").get();
                  if (mainDoc.exists) {
                      const data = mainDoc.data();
                      const legacySchedules = data.schedules || {};
                      if (legacySchedules[weekId]) {
                          weekData = legacySchedules[weekId];
-                         await db.collection("weeks").doc(weekId).set(weekData);
+                         await weeksRef.doc(weekId).set(weekData);
+                     }
+                 } else {
+                     const legacyWeekDoc = await legacyWeeksRef().doc(weekId).get();
+                     if (legacyWeekDoc.exists) {
+                        weekData = legacyWeekDoc.data();
                      }
                  }
             }

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -1,0 +1,162 @@
+import { store } from '../store/Store.js';
+import { initFirebase, getAuth, getDb } from './firebase.js';
+import { userDocRef } from './firestoreRefs.js';
+
+const STORAGE_KEY = 'activeStoreId';
+
+function createSelectionUI(stores, onSelect, onLogout) {
+  let overlay = document.getElementById('store-selector');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'store-selector';
+    overlay.className = 'store-selector-overlay';
+    overlay.innerHTML = `
+      <div class="card" style="max-width:480px; width:100%;">
+        <div class="card-h"><strong>Elegí tu local</strong></div>
+        <div class="card-c stack" id="store-selector-body"></div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+  }
+  const body = overlay.querySelector('#store-selector-body');
+  body.innerHTML = '';
+  const list = document.createElement('div');
+  list.className = 'stack';
+  stores.forEach((storeId) => {
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = storeId;
+    btn.addEventListener('click', () => onSelect(storeId));
+    list.appendChild(btn);
+  });
+  body.appendChild(list);
+  const cancelRow = document.createElement('div');
+  cancelRow.className = 'row';
+  cancelRow.style.justifyContent = 'space-between';
+  const logoutBtn = document.createElement('button');
+  logoutBtn.className = 'btn secondary';
+  logoutBtn.textContent = 'Cerrar sesión';
+  logoutBtn.addEventListener('click', onLogout);
+  cancelRow.appendChild(logoutBtn);
+  body.appendChild(cancelRow);
+  overlay.style.display = 'flex';
+}
+
+function hideSelectionUI() {
+  const overlay = document.getElementById('store-selector');
+  if (overlay) overlay.style.display = 'none';
+}
+
+function showSessionBanner(onChangeStore, onLogout) {
+  let banner = document.getElementById('session-banner');
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'session-banner';
+    banner.className = 'session-banner';
+    banner.innerHTML = `
+      <div class="row" style="gap:8px; align-items:center;">
+        <span class="pill" id="session-user-label"></span>
+        <span class="pill pill-neutral" id="session-store-label"></span>
+        <button id="change-store-btn" class="btn secondary">Cambiar local</button>
+        <button id="logout-btn" class="btn secondary">Salir</button>
+      </div>
+    `;
+    const bar = document.querySelector('.bar-inner');
+    if (bar) bar.appendChild(banner); else document.body.prepend(banner);
+  }
+  const changeBtn = banner.querySelector('#change-store-btn');
+  changeBtn.onclick = onChangeStore;
+  const logoutBtn = banner.querySelector('#logout-btn');
+  logoutBtn.onclick = onLogout;
+  banner.style.display = 'block';
+}
+
+function updateBannerLabels() {
+  const state = store.getState();
+  const userLbl = document.getElementById('session-user-label');
+  const storeLbl = document.getElementById('session-store-label');
+  if (userLbl) userLbl.textContent = state.currentUser?.displayName || state.currentUser?.email || 'Sin usuario';
+  if (storeLbl) storeLbl.textContent = state.activeStoreId ? `Local activo: ${state.activeStoreId}` : 'Sin local activo';
+}
+
+export const SessionService = {
+  async requireSession() {
+    initFirebase();
+    const auth = getAuth();
+    return new Promise((resolve, reject) => {
+      auth.onAuthStateChanged(async (user) => {
+        try {
+          if (!user) {
+            window.location.href = 'index.html';
+            return;
+          }
+          const profileSnap = await userDocRef(user.uid).get();
+          if (!profileSnap.exists) {
+            console.error('Usuario sin permisos');
+            alert('Usuario sin permisos.');
+            await auth.signOut();
+            window.location.href = 'index.html';
+            return;
+          }
+          const profile = profileSnap.data();
+          const allowedStores = Array.isArray(profile.allowedStores) ? profile.allowedStores : [];
+          const defaultStore = profile.defaultStore || null;
+          const persisted = localStorage.getItem(STORAGE_KEY);
+          let activeStoreId = null;
+          if (persisted && allowedStores.includes(persisted)) {
+            activeStoreId = persisted;
+          } else if (allowedStores.length === 1) {
+            activeStoreId = allowedStores[0];
+          } else if (defaultStore && allowedStores.includes(defaultStore)) {
+            activeStoreId = defaultStore;
+          }
+
+          store.setState({
+            currentUser: {
+              uid: user.uid,
+              email: user.email,
+              displayName: profile.displayName || user.displayName || user.email,
+              role: profile.role || 'manager',
+              allowedStores,
+              defaultStore,
+            },
+            activeStoreId,
+          });
+          updateBannerLabels();
+
+          const logout = async () => {
+            await auth.signOut();
+            localStorage.removeItem(STORAGE_KEY);
+            window.location.href = 'index.html';
+          };
+          const handleSelect = (storeId) => {
+            localStorage.setItem(STORAGE_KEY, storeId);
+            store.setState({ activeStoreId: storeId, schedules: {}, employees: [] });
+            hideSelectionUI();
+            updateBannerLabels();
+            document.dispatchEvent(new CustomEvent('store-changed', { detail: { storeId } }));
+            resolve(storeId);
+          };
+
+          showSessionBanner(() => {
+            createSelectionUI(allowedStores, handleSelect, logout);
+          }, logout);
+
+          if (activeStoreId) {
+            resolve(activeStoreId);
+          } else if (allowedStores.length > 1) {
+            createSelectionUI(allowedStores, handleSelect, logout);
+          } else {
+            alert('No hay locales habilitados para este usuario.');
+            reject(new Error('Sin locales')); // will show overlay still
+          }
+        } catch (err) {
+          console.error('Error cargando sesión', err);
+          reject(err);
+        }
+      });
+    });
+  }
+};
+
+store.subscribe(updateBannerLabels);

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -1,0 +1,33 @@
+import { firebaseConfig } from '../config.js';
+
+let app = null;
+let firestore = null;
+let auth = null;
+
+export function initFirebase() {
+  if (typeof firebase === 'undefined') {
+    console.error('Firebase SDK no cargado.');
+    return null;
+  }
+  if (!app) {
+    app = firebase.initializeApp(firebaseConfig);
+  }
+  if (!firestore) firestore = firebase.firestore();
+  if (!auth) auth = firebase.auth();
+  return app;
+}
+
+export function getAuth() {
+  if (!auth) initFirebase();
+  return auth;
+}
+
+export function getDb() {
+  if (!firestore) initFirebase();
+  return firestore;
+}
+
+export function getFirebaseApp() {
+  if (!app) initFirebase();
+  return app;
+}

--- a/src/services/firestoreRefs.js
+++ b/src/services/firestoreRefs.js
@@ -1,0 +1,46 @@
+import { getDb } from './firebase.js';
+
+export function storeDoc(storeId) {
+  return getDb().collection('stores').doc(storeId);
+}
+
+export function storeEmployeesRef(storeId) {
+  return storeDoc(storeId).collection('employees');
+}
+
+export function storeSchedulesRef(storeId) {
+  return storeDoc(storeId).collection('schedules');
+}
+
+export function storeWeeksRef(storeId) {
+  return storeDoc(storeId).collection('weeks');
+}
+
+export function storeSolicitudesRef(storeId) {
+  return storeDoc(storeId).collection('solicitudes');
+}
+
+export function storeSettingsRef(storeId) {
+  return storeDoc(storeId).collection('settings');
+}
+
+// Compatibilidad: referencias legacy centralizadas
+export function legacyEmployeesRef() {
+  return getDb().collection('employees');
+}
+
+export function legacySchedulesRef() {
+  return getDb().collection('schedules');
+}
+
+export function legacyWeeksRef() {
+  return getDb().collection('weeks');
+}
+
+export function legacySolicitudesRef() {
+  return getDb().collection('solicitudes');
+}
+
+export function userDocRef(uid) {
+  return getDb().collection('users').doc(uid);
+}

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -36,6 +36,8 @@ import { HistoryManager } from '../history.js';
 import { ROLES } from '../config.js';
 
 const defaultState = {
+    currentUser: null,
+    activeStoreId: null,
     employees: [],
     schedules: {}, // Will now act as a cache or hold only current week?
                    // Plan: schedules will hold loaded weeks. activeWeek points to current.

--- a/style.css
+++ b/style.css
@@ -1623,3 +1623,20 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
 
 .slot.assigned.unavailable-slot .label,
 .slot.assigned.unavailable-slot { position: relative; z-index: 1; }
+
+/* Multi-local UI helpers */
+.store-selector-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 999;
+}
+
+.session-banner {
+  margin-left: auto;
+  display: none;
+}


### PR DESCRIPTION
## Resumen
- incorpora servicio de sesión que exige documento users/{uid}, selección de local y banner de contexto
- refactoriza acceso a Firestore para usar rutas stores/{storeId} con helpers y caídas controladas a legacy
- ajusta reglas, login y módulos de solicitudes/empleados; agrega script y guía de migración multi-local

## Testing
- Sin pruebas automáticas ejecutadas

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941cdf9f9e4832d839c47958da11339)