### PR TITLE
Show availability warnings in schedule list and warn on exception conflicts

### DIFF
--- a/src/modules/EmployeeManager.js
+++ b/src/modules/EmployeeManager.js
@@ -1,9 +1,9 @@
 import { el, create, clear } from '../utils/dom.js';
 import { store } from '../store/Store.js';
 import { DataManager } from '../services/DataManager.js';
-import { getActiveSchedule } from '../store/Store.js';
-import { ROLES } from '../config.js';
+import { ROLES, SLOTS } from '../config.js';
 import { storeEmployeesRef, legacyEmployeesRef } from '../services/firestoreRefs.js';
+import { getMonday, toISODateString } from '../utils/date.js';
 
 const EXPORT_FIELD_CONFIG = {
     name: { label: 'Nombre completo', getter: (e) => e.name || '' },
@@ -613,7 +613,7 @@ export const EmployeeManager = {
         const startInput = create("input", { type: "time", className: "input", title: "Inicio (opcional)" });
         const endInput = create("input", { type: "time", className: "input", title: "Fin (opcional)" });
 
-        const addBtn = create("button", { className: "btn", textContent: "Añadir", onClick: () => {
+        const addBtn = create("button", { className: "btn", textContent: "Añadir", onClick: async () => {
             if(dateInput.value) {
                 if(!emp.exceptions) emp.exceptions = [];
                 const newEx = {
@@ -626,6 +626,19 @@ export const EmployeeManager = {
                 if ((newEx.start && !newEx.end) || (!newEx.start && newEx.end)) {
                     alert("Para excepción parcial, ingresa Inicio y Fin.");
                     return;
+                }
+
+                const conflictShifts = await this.getEmployeeShiftsForDate(emp.id, dateInput.value);
+                if (conflictShifts.length > 0) {
+                    const summary = conflictShifts.map(s => this.formatShiftRange(s)).filter(Boolean).join(' | ');
+                    const promptText = [
+                        `⚠️ ${emp.name} ya tiene ${conflictShifts.length === 1 ? 'un turno' : `${conflictShifts.length} turnos`} asignado${conflictShifts.length === 1 ? '' : 's'} ese día.`,
+                        summary ? `Horarios: ${summary}.` : '',
+                        '',
+                        '¿Querés registrar la excepción igualmente?'
+                    ].filter(Boolean).join('\n');
+                    const proceed = confirm(promptText);
+                    if (!proceed) return;
                 }
 
                 emp.exceptions.push(newEx);
@@ -648,6 +661,33 @@ export const EmployeeManager = {
         panel.appendChild(create("div", { className: "hr" }));
         panel.appendChild(addRow);
         container.appendChild(panel);
+    },
+
+    async getEmployeeShiftsForDate(empId, dateString) {
+        if (!dateString) return [];
+
+        const parsedDate = new Date(`${dateString}T12:00:00.000Z`);
+        if (Number.isNaN(parsedDate.getTime())) return [];
+
+        const monday = getMonday(parsedDate);
+        const weekId = toISODateString(monday);
+        const dayIndex = parsedDate.getDay() === 0 ? 6 : parsedDate.getDay() - 1;
+
+        const weekData = await DataManager.getWeekData(weekId);
+        const dayShifts = Array.isArray(weekData?.[dayIndex]) ? weekData[dayIndex] : [];
+
+        return dayShifts.filter(shift => shift?.employeeId === empId);
+    },
+
+    formatShiftRange(shift) {
+        if (!shift) return '';
+        const startLabel = SLOTS[shift.startSlot]?.label || '';
+        const endLabel = SLOTS[shift.endSlot + 1]?.label || '';
+
+        if (!startLabel && !endLabel) return '';
+        if (!startLabel || !endLabel) return `${startLabel || endLabel}`;
+
+        return `${startLabel} - ${endLabel}`;
     },
 
     renderSanctionsPanel(container, empId) {

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1524,6 +1524,21 @@ export const ScheduleManager = {
         document.body.appendChild(wrap);
     },
 
+    getDayRestrictionInfo(employee, shiftDate, shiftDateString) {
+        if (!employee) return { blocked: false, reason: '' };
+
+        if (isDateInSanctionPeriod(shiftDate, employee.sanctions)) {
+            return { blocked: true, reason: 'Licencia activa' };
+        }
+
+        const hasFullDayException = (employee.exceptions || []).some(ex => ex.date === shiftDateString && !ex.start && !ex.end);
+        if (hasFullDayException) {
+            return { blocked: true, reason: 'Excepción de día completo' };
+        }
+
+        return { blocked: false, reason: '' };
+    },
+
     renderScheduleList() {
         const content = el("#schedule-list-content");
         if(!content) return;
@@ -1614,6 +1629,17 @@ export const ScheduleManager = {
 
             for (let dayIndex = 0; dayIndex < 7; dayIndex++) {
                 const dayCell = create("td", { dataset: { day: dayIndex } });
+                const shiftDate = new Date(weekMonday);
+                shiftDate.setDate(weekMonday.getDate() + dayIndex);
+                const shiftDateString = toISODateString(shiftDate);
+
+                const restrictionInfo = this.getDayRestrictionInfo(emp, shiftDate, shiftDateString);
+                if (restrictionInfo.blocked) {
+                    const warningEl = create("div", { className: "schedule-list-warning", title: restrictionInfo.reason });
+                    warningEl.innerHTML = `⚠️ <span>${restrictionInfo.reason}</span>`;
+                    dayCell.appendChild(warningEl);
+                }
+
                 const dayShifts = (schedule[dayIndex] || []).filter(s => s.employeeId === emp.id);
                 if (dayShifts.length > 0) {
                     const shiftsContainer = create("div", { className: "shifts-container" });
@@ -1644,14 +1670,10 @@ export const ScheduleManager = {
                         }
                         shiftDiv.innerHTML = shiftText;
 
-                        // Sanction conflict visual
-                        const weekMonday = new Date(state.activeWeek + "T12:00:00Z");
-                        const shiftDate = new Date(weekMonday);
-                        shiftDate.setDate(shiftDate.getDate() + dayIndex);
-
-                        if (isDateInSanctionPeriod(shiftDate, emp.sanctions) && !shift.replacement) {
+                        // Day restriction visual
+                        if (restrictionInfo.blocked && !shift.replacement) {
                             shiftDiv.style.border = `2px solid var(--c-danger)`;
-                            shiftDiv.title = 'Conflicto con sanción/licencia';
+                            shiftDiv.title = restrictionInfo.reason;
                         }
 
                         shiftDiv.addEventListener('dragstart', (e) => {

--- a/style.css
+++ b/style.css
@@ -983,6 +983,23 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
   transform: scale(1.03);
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
 }
+.schedule-list-warning {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: center;
+  color: #92400e;
+  background: rgba(251, 191, 36, 0.18);
+  border: 1px solid rgba(245, 158, 11, 0.6);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+.dark-mode .schedule-list-warning {
+  color: #fcd34d;
+  border-color: rgba(234, 179, 8, 0.7);
+}
 
 /* Shift Context Menu */
 .shift-context-menu {


### PR DESCRIPTION
## Summary
- show warning badges in the schedule list when an employee has a full-day exception or active license for that date
- highlight affected shifts and style the warning badge for clearer visibility
- prompt when adding a new exception if the employee already has shifts scheduled that day

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0fd05b24832d95d069ff21df4724)