### PR TITLE
Improve warning UI and replace browser dialogs with in-app modals

### DIFF
--- a/src/modules/EmployeeManager.js
+++ b/src/modules/EmployeeManager.js
@@ -1,9 +1,10 @@
 import { el, create, clear } from '../utils/dom.js';
 import { store } from '../store/Store.js';
 import { DataManager } from '../services/DataManager.js';
-import { getActiveSchedule } from '../store/Store.js';
-import { ROLES } from '../config.js';
+import { ROLES, SLOTS } from '../config.js';
 import { storeEmployeesRef, legacyEmployeesRef } from '../services/firestoreRefs.js';
+import { getMonday, toISODateString } from '../utils/date.js';
+import { showToast, showConfirmDialog, showAlertDialog } from '../utils/feedback.js';
 
 const EXPORT_FIELD_CONFIG = {
     name: { label: 'Nombre completo', getter: (e) => e.name || '' },
@@ -191,10 +192,10 @@ export const EmployeeManager = {
 
                 store.setState({ employees });
                 DataManager.saveState();
-                alert(`Se importaron ${importedCount} empleados.`);
+                showToast(`Se importaron ${importedCount} empleados.`, "success");
             } catch (err) {
                 console.error(err);
-                alert('Error al importar empleados.');
+                showToast('Error al importar empleados.', "error");
             }
         };
         reader.readAsArrayBuffer(file);
@@ -405,8 +406,12 @@ export const EmployeeManager = {
         }
     },
 
-    removeEmployee(empId) {
-        if(!confirm("¿Eliminar empleado?")) return;
+    async removeEmployee(empId) {
+        const confirmed = await showConfirmDialog({
+            title: "Eliminar empleado",
+            message: "¿Eliminar empleado?"
+        });
+        if(!confirmed) return;
         const state = store.getState();
         const newEmployees = state.employees.filter(e => e.id !== empId);
         store.setState({ employees: newEmployees });
@@ -613,7 +618,7 @@ export const EmployeeManager = {
         const startInput = create("input", { type: "time", className: "input", title: "Inicio (opcional)" });
         const endInput = create("input", { type: "time", className: "input", title: "Fin (opcional)" });
 
-        const addBtn = create("button", { className: "btn", textContent: "Añadir", onClick: () => {
+        const addBtn = create("button", { className: "btn", textContent: "Añadir", onClick: async () => {
             if(dateInput.value) {
                 if(!emp.exceptions) emp.exceptions = [];
                 const newEx = {
@@ -624,15 +629,32 @@ export const EmployeeManager = {
                 // If only one time is set, it's invalid for range, assume full day?
                 // Or require both for partial.
                 if ((newEx.start && !newEx.end) || (!newEx.start && newEx.end)) {
-                    alert("Para excepción parcial, ingresa Inicio y Fin.");
+                    showToast("Para excepción parcial, ingresa Inicio y Fin.", "warning");
                     return;
+                }
+
+                const conflictShifts = await this.getEmployeeShiftsForDate(emp.id, dateInput.value);
+                if (conflictShifts.length > 0) {
+                    const summary = conflictShifts.map(s => this.formatShiftRange(s)).filter(Boolean).join(' | ');
+                    const promptText = [
+                        `⚠️ ${emp.name} ya tiene ${conflictShifts.length === 1 ? 'un turno' : `${conflictShifts.length} turnos`} asignado${conflictShifts.length === 1 ? '' : 's'} ese día.`,
+                        summary ? `Horarios: ${summary}.` : '',
+                        '',
+                        '¿Querés registrar la excepción igualmente?'
+                    ].filter(Boolean).join('\n');
+                    const proceed = await showConfirmDialog({
+                        title: "Conflicto de horarios",
+                        message: promptText.replace(/\n/g, "<br>"),
+                        confirmText: "Registrar igualmente"
+                    });
+                    if (!proceed) return;
                 }
 
                 emp.exceptions.push(newEx);
                 DataManager.saveState();
                 this.renderList();
             } else {
-                alert("Ingresa una fecha.");
+                showToast("Ingresa una fecha.", "warning");
             }
         }});
 
@@ -648,6 +670,33 @@ export const EmployeeManager = {
         panel.appendChild(create("div", { className: "hr" }));
         panel.appendChild(addRow);
         container.appendChild(panel);
+    },
+
+    async getEmployeeShiftsForDate(empId, dateString) {
+        if (!dateString) return [];
+
+        const parsedDate = new Date(`${dateString}T12:00:00.000Z`);
+        if (Number.isNaN(parsedDate.getTime())) return [];
+
+        const monday = getMonday(parsedDate);
+        const weekId = toISODateString(monday);
+        const dayIndex = parsedDate.getDay() === 0 ? 6 : parsedDate.getDay() - 1;
+
+        const weekData = await DataManager.getWeekData(weekId);
+        const dayShifts = Array.isArray(weekData?.[dayIndex]) ? weekData[dayIndex] : [];
+
+        return dayShifts.filter(shift => shift?.employeeId === empId);
+    },
+
+    formatShiftRange(shift) {
+        if (!shift) return '';
+        const startLabel = SLOTS[shift.startSlot]?.label || '';
+        const endLabel = SLOTS[shift.endSlot + 1]?.label || '';
+
+        if (!startLabel && !endLabel) return '';
+        if (!startLabel || !endLabel) return `${startLabel || endLabel}`;
+
+        return `${startLabel} - ${endLabel}`;
     },
 
     renderSanctionsPanel(container, empId) {
@@ -719,7 +768,7 @@ export const EmployeeManager = {
 
         actionRow.appendChild(create("button", { className: "btn", textContent: "Añadir", onClick: () => {
             if (startInput.value && endInput.value && descInput.value) {
-                if (new Date(endInput.value) < new Date(startInput.value)) { alert("Fin < Inicio"); return; }
+                if (new Date(endInput.value) < new Date(startInput.value)) { showToast("La fecha de fin no puede ser menor que la de inicio.", "warning"); return; }
                 if(!emp.sanctions) emp.sanctions = [];
                 emp.sanctions.push({
                     id: crypto.randomUUID(),
@@ -730,7 +779,7 @@ export const EmployeeManager = {
                 });
                 this.renderSanctionsPanel(container, empId);
             } else {
-                alert("Complete todos los campos.");
+                showToast("Complete todos los campos.", "warning");
             }
         }}));
         stack.appendChild(actionRow);
@@ -798,13 +847,13 @@ export const EmployeeManager = {
     exportSelected(format = 'excel') {
         const selectedFields = this.getSelectedExportFields();
         if (!selectedFields.length) {
-            alert('Seleccioná al menos un dato para exportar.');
+            showToast('Seleccioná al menos un dato para exportar.', 'warning');
             return;
         }
 
         const employees = Array.isArray(store.getState().employees) ? store.getState().employees : [];
         if (!employees.length) {
-            alert('No hay empleados para exportar.');
+            showToast('No hay empleados para exportar.', 'info');
             return;
         }
 
@@ -834,7 +883,7 @@ export const EmployeeManager = {
         if (!rows.length) return;
         const jspdfLib = window.jspdf;
         if (!jspdfLib || !jspdfLib.jsPDF) {
-            alert('No se pudo cargar el exportador PDF.');
+            showToast('No se pudo cargar el exportador PDF.', 'error');
             return;
         }
         const { jsPDF } = jspdfLib;

--- a/src/modules/ImportExportManager.js
+++ b/src/modules/ImportExportManager.js
@@ -6,6 +6,7 @@ import { timeToSlotIndex } from '../utils/rules.js';
 import { toISODateString } from '../utils/date.js';
 import { EmployeeManager } from './EmployeeManager.js';
 import { ScheduleManager } from './ScheduleManager.js';
+import { showToast, showConfirmDialog, showAlertDialog } from '../utils/feedback.js';
 
 export const ImportExportManager = {
     init() {
@@ -34,9 +35,9 @@ export const ImportExportManager = {
         el("#file-import-week")?.addEventListener("change", (e) => this.importWeek(e));
     },
 
-    importShiftsFromText() {
+    async importShiftsFromText() {
         const text = el("#import-text-area").value.trim();
-        if (!text) { alert("Vacío."); return; }
+        if (!text) { showToast("El texto está vacío.", "warning"); return; }
 
         const lines = text.split('\n');
         const newShifts = [];
@@ -72,10 +73,17 @@ export const ImportExportManager = {
             });
         });
 
-        if (errors.length > 0) { alert("Errores:\n" + errors.join("\n")); return; }
-        if (newShifts.length === 0) { alert("Nada para importar."); return; }
+        if (errors.length > 0) {
+            await showAlertDialog({ title: "Revisá los datos", message: errors.join("<br>") });
+            return;
+        }
+        if (newShifts.length === 0) { showToast("Nada para importar.", "warning"); return; }
 
-        if (!confirm(`Importar ${newShifts.length} turnos?`)) return;
+        const confirmed = await showConfirmDialog({
+            title: "Importar turnos",
+            message: `Importar ${newShifts.length} turnos en el día seleccionado?`
+        });
+        if (!confirmed) return;
 
         const state = store.getState();
         ScheduleManager.commitChange(() => {
@@ -84,7 +92,7 @@ export const ImportExportManager = {
         });
 
         el("#import-text-modal").style.display = "none";
-        alert("Importado.");
+        showToast("Turnos importados correctamente.", "success");
     },
 
     exportEmployees() {
@@ -95,7 +103,7 @@ export const ImportExportManager = {
         const file = e.target.files?.[0];
         if (!file) return;
         const reader = new FileReader();
-        reader.onload = (ev) => {
+        reader.onload = async (ev) => {
             try {
                 const imported = JSON.parse(ev.target.result);
                 if (!Array.isArray(imported)) throw new Error("No es array");
@@ -103,15 +111,19 @@ export const ImportExportManager = {
                 const existingIds = new Set(current.map(emp => emp.id));
                 const newEmps = imported.filter(emp => emp.id && !existingIds.has(emp.id));
 
-                if (newEmps.length === 0) { alert("No hay nuevos empleados."); return; }
-                if (confirm(`Importar ${newEmps.length} empleados?`)) {
-                    store.setState({ employees: [...current, ...newEmps] });
-                    DataManager.saveState();
-                    EmployeeManager.renderList();
-                    alert("Importado.");
-                    el("#advanced-import-export-modal").style.display = "none";
-                }
-            } catch (err) { alert("Error: " + err.message); }
+                if (newEmps.length === 0) { showToast("No hay nuevos empleados.", "info"); return; }
+                const confirmed = await showConfirmDialog({
+                    title: "Importar empleados",
+                    message: `Importar ${newEmps.length} empleados nuevos?`
+                });
+                if (!confirmed) return;
+
+                store.setState({ employees: [...current, ...newEmps] });
+                DataManager.saveState();
+                EmployeeManager.renderList();
+                showToast("Empleados importados.", "success");
+                el("#advanced-import-export-modal").style.display = "none";
+            } catch (err) { showToast("Error al importar: " + err.message, "error"); }
             e.target.value = '';
         };
         reader.readAsText(file);
@@ -128,21 +140,25 @@ export const ImportExportManager = {
         const file = e.target.files?.[0];
         if (!file) return;
         const reader = new FileReader();
-        reader.onload = (ev) => {
+        reader.onload = async (ev) => {
             try {
                 const imported = JSON.parse(ev.target.result);
                 if (!Array.isArray(imported)) throw new Error("Formato inválido");
-                if (confirm("Reemplazar turnos del día actual?")) {
-                    const newShifts = imported.map(s => ({ ...s, id: crypto.randomUUID() }));
-                    const state = store.getState();
-                    ScheduleManager.commitChange(() => {
-                        const schedule = getActiveSchedule();
-                        schedule[state.activeDay] = newShifts;
-                    });
-                    alert("Importado.");
-                    el("#advanced-import-export-modal").style.display = "none";
-                }
-            } catch (err) { alert("Error: " + err.message); }
+                const confirmed = await showConfirmDialog({
+                    title: "Reemplazar turnos del día",
+                    message: "Reemplazar turnos del día actual con los importados?"
+                });
+                if (!confirmed) return;
+
+                const newShifts = imported.map(s => ({ ...s, id: crypto.randomUUID() }));
+                const state = store.getState();
+                ScheduleManager.commitChange(() => {
+                    const schedule = getActiveSchedule();
+                    schedule[state.activeDay] = newShifts;
+                });
+                showToast("Turnos del día importados.", "success");
+                el("#advanced-import-export-modal").style.display = "none";
+            } catch (err) { showToast("Error al importar: " + err.message, "error"); }
             e.target.value = '';
         };
         reader.readAsText(file);
@@ -166,29 +182,33 @@ export const ImportExportManager = {
         const file = e.target.files?.[0];
         if (!file) return;
         const reader = new FileReader();
-        reader.onload = (ev) => {
+        reader.onload = async (ev) => {
             try {
                 const imported = JSON.parse(ev.target.result);
                 if (typeof imported !== 'object') throw new Error("Formato inválido");
-                if (confirm("Reemplazar semana actual?")) {
-                    const newWeek = JSON.parse(JSON.stringify(imported));
-                    for (const day in newWeek) {
-                        if (Array.isArray(newWeek[day])) {
-                            newWeek[day].forEach(s => s.id = crypto.randomUUID());
-                        }
+                const confirmed = await showConfirmDialog({
+                    title: "Reemplazar semana",
+                    message: "Reemplazar la semana actual con el archivo importado?"
+                });
+                if (!confirmed) return;
+
+                const newWeek = JSON.parse(JSON.stringify(imported));
+                for (const day in newWeek) {
+                    if (Array.isArray(newWeek[day])) {
+                        newWeek[day].forEach(s => s.id = crypto.randomUUID());
                     }
-                    store.setState({
-                        schedules: {
-                            ...store.getState().schedules,
-                            [store.getState().activeWeek]: newWeek
-                        }
-                    });
-                    DataManager.saveState();
-                    ScheduleManager.render();
-                    alert("Importado.");
-                    el("#advanced-import-export-modal").style.display = "none";
                 }
-            } catch (err) { alert("Error: " + err.message); }
+                store.setState({
+                    schedules: {
+                        ...store.getState().schedules,
+                        [store.getState().activeWeek]: newWeek
+                    }
+                });
+                DataManager.saveState();
+                ScheduleManager.render();
+                showToast("Semana importada.", "success");
+                el("#advanced-import-export-modal").style.display = "none";
+            } catch (err) { showToast("Error al importar: " + err.message, "error"); }
             e.target.value = '';
         };
         reader.readAsText(file);

--- a/src/modules/OptionsManager.js
+++ b/src/modules/OptionsManager.js
@@ -2,6 +2,7 @@ import { el, create, clear } from '../utils/dom.js';
 import { store } from '../store/Store.js';
 import { ROLES, setRoles, DEFAULT_ROLES } from '../config.js';
 import { DataManager } from '../services/DataManager.js';
+import { showToast, showConfirmDialog } from '../utils/feedback.js';
 
 export const OptionsManager = {
     init() {
@@ -31,11 +32,11 @@ export const OptionsManager = {
         if (!nameInput || !colorInput || !darkTextInput) return;
 
         const name = nameInput.value.trim();
-        if (!name) return alert('Ingresá un nombre para el puesto.');
+        if (!name) return showToast('Ingresá un nombre para el puesto.', 'warning');
 
         const roles = this.getRoles();
         if (roles.some(r => r.key.toLowerCase() === name.toLowerCase())) {
-            return alert('Ya existe un puesto con ese nombre.');
+            return showToast('Ya existe un puesto con ese nombre.', 'warning');
         }
 
         const newRole = {
@@ -49,8 +50,12 @@ export const OptionsManager = {
         nameInput.value = '';
     },
 
-    handleReset() {
-        if (!confirm('¿Restaurar la lista de puestos original?')) return;
+    async handleReset() {
+        const confirmed = await showConfirmDialog({
+            title: 'Restaurar puestos',
+            message: '¿Restaurar la lista de puestos original?'
+        });
+        if (!confirmed) return;
         this.persistRoles([...DEFAULT_ROLES]);
     },
 
@@ -69,11 +74,15 @@ export const OptionsManager = {
         this.persistRoles(roles);
     },
 
-    deleteRole(index) {
+    async deleteRole(index) {
         const roles = [...this.getRoles()];
         const role = roles[index];
         if (!role) return;
-        if (!confirm(`¿Eliminar el puesto "${role.key}"?`)) return;
+        const confirmed = await showConfirmDialog({
+            title: 'Eliminar puesto',
+            message: `¿Eliminar el puesto "${role.key}"?`
+        });
+        if (!confirmed) return;
         roles.splice(index, 1);
         this.persistRoles(roles);
     },

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -13,6 +13,7 @@ import {
 } from '../utils/rules.js';
 import { getMonday, toISODateString } from '../utils/date.js';
 import { EmployeeManager } from './EmployeeManager.js';
+import { showToast, showConfirmDialog, showAlertDialog } from '../utils/feedback.js';
 
 export const ScheduleManager = {
     init() {
@@ -282,11 +283,23 @@ export const ScheduleManager = {
             const actions = create("div", { style: { display: "flex", gap: "5px" } });
             actions.appendChild(create("button", {
                 className: "btn small", textContent: "Aplicar",
-                onClick: () => { if(confirm(`¿Aplicar plantilla "${name}"? Esto sobrescribirá el día actual.`)) this.applyTemplate(name); }
+                onClick: async () => {
+                    const confirmed = await showConfirmDialog({
+                        title: "Aplicar plantilla",
+                        message: `¿Aplicar plantilla "${name}"? Esto sobrescribirá el día actual.`
+                    });
+                    if (confirmed) this.applyTemplate(name);
+                }
             }));
             actions.appendChild(create("button", {
                 className: "btn small secondary del", innerHTML: "&times;",
-                onClick: () => { if(confirm(`¿Eliminar plantilla "${name}"?`)) this.deleteTemplate(name); }
+                onClick: async () => {
+                    const confirmed = await showConfirmDialog({
+                        title: "Eliminar plantilla",
+                        message: `¿Eliminar plantilla "${name}"?`
+                    });
+                    if (confirmed) this.deleteTemplate(name);
+                }
             }));
 
             item.appendChild(actions);
@@ -294,7 +307,7 @@ export const ScheduleManager = {
         });
     },
 
-    saveCurrentDayAsTemplate() {
+    async saveCurrentDayAsTemplate() {
         const nameInp = el("#inpTemplateName");
         const descInp = el("#inpTemplateDesc");
         if (!nameInp) return;
@@ -302,11 +315,15 @@ export const ScheduleManager = {
         const name = nameInp.value.trim();
         const description = descInp ? descInp.value.trim() : "";
 
-        if (!name) { alert("Ingresa un nombre para la plantilla."); return; }
+        if (!name) { showToast("Ingresa un nombre para la plantilla.", "warning"); return; }
 
         const state = store.getState();
         if (state.templates && state.templates[name]) {
-            if (!confirm(`La plantilla "${name}" ya existe. ¿Sobrescribirla?`)) return;
+            const confirmed = await showConfirmDialog({
+                title: "Sobrescribir plantilla",
+                message: `La plantilla "${name}" ya existe. ¿Sobrescribirla?`
+            });
+            if (!confirmed) return;
         }
 
         const schedule = getActiveSchedule();
@@ -328,7 +345,7 @@ export const ScheduleManager = {
         nameInp.value = "";
         if(descInp) descInp.value = "";
         this.renderTemplateList();
-        alert("Plantilla guardada.");
+        showToast("Plantilla guardada.", "success");
     },
 
     applyTemplate(name) {
@@ -523,7 +540,14 @@ export const ScheduleManager = {
                 actionsDiv.appendChild(create("button", {
                     className: "btn secondary del", innerHTML: "&times;",
                     style: { padding: "2px 6px", fontSize: "10px" }, title: "Eliminar turno",
-                    onClick: (e) => { e.stopPropagation(); if(confirm("¿Eliminar este turno?")) this.deleteShift(shift.id); }
+                    onClick: async (e) => {
+                        e.stopPropagation();
+                        const confirmed = await showConfirmDialog({
+                            title: "Eliminar turno",
+                            message: "¿Eliminar este turno?"
+                        });
+                        if (confirmed) this.deleteShift(shift.id);
+                    }
                 }));
                 namecol.appendChild(actionsDiv);
                 row.appendChild(namecol);
@@ -684,7 +708,7 @@ export const ScheduleManager = {
         const startSlot = Number(el("#formStart").value);
         const endSlot = Number(el("#formEnd").value);
         if(Number.isNaN(startSlot) || Number.isNaN(endSlot) || endSlot <= startSlot) {
-            alert("La hora de fin debe ser posterior a la hora de inicio.");
+            showToast("La hora de fin debe ser posterior a la hora de inicio.", "warning");
             return;
         }
 
@@ -1217,7 +1241,7 @@ export const ScheduleManager = {
         DataManager.loadWeek(newWeek);
     },
 
-    autoAssignShifts() {
+    async autoAssignShifts() {
         const schedule = getActiveSchedule();
         const state = store.getState();
         let assignedCount = 0;
@@ -1235,11 +1259,15 @@ export const ScheduleManager = {
         }
 
         if (totalUnassigned.length === 0) {
-            alert("No hay turnos vacíos para asignar.");
+            showToast("No hay turnos vacíos para asignar.", "info");
             return;
         }
 
-        if (!confirm(`Se encontraron ${totalUnassigned.length} turnos vacíos.\n\nEl sistema asignará turnos respetando:\n1. Mínimo de 14hs semanales.\n2. Prioridad (Muy Alta > Muy Baja).\n3. Menor carga horaria actual.\n\n¿Continuar?`)) {
+        const confirmed = await showConfirmDialog({
+            title: "Autoasignar turnos",
+            message: `Se encontraron ${totalUnassigned.length} turnos vacíos.<br><br>El sistema asignará turnos respetando:<br>1. Mínimo de 14hs semanales.<br>2. Prioridad (Muy Alta > Muy Baja).<br>3. Menor carga horaria actual.<br><br>¿Continuar?`
+        });
+        if (!confirmed) {
             return;
         }
 
@@ -1329,7 +1357,10 @@ export const ScheduleManager = {
             }
         });
 
-        alert(`Proceso completado.\n\n- Asignados: ${assignedCount}\n- Sin candidato válido: ${skippedCount}`);
+        showAlertDialog({
+            title: "Autoasignación completada",
+            message: `Asignados: ${assignedCount}<br>Sin candidato válido: ${skippedCount}`
+        });
     },
 
 
@@ -1339,7 +1370,7 @@ export const ScheduleManager = {
         this.ensureDay(day);
         const schedule = getActiveSchedule();
         const shift = schedule[day].find(s => s.id === shiftId);
-        if (!shift) { alert("No se encontró el turno."); return; }
+        if (!shift) { showToast("No se encontró el turno.", "error"); return; }
 
         const wrap = create("div", { style: { position:"fixed", inset:"0", background:"rgba(0,0,0,.35)", display:"flex", alignItems:"center", justifyContent:"center", padding:"16px", zIndex:1000 }});
         const box = create("div", { className:"card", style:{ maxWidth:"600px", width:"100%" } });
@@ -1436,8 +1467,14 @@ export const ScheduleManager = {
                     btn.disabled = true;
                     btn.style.opacity = 0.6;
                 } else {
-                    btn.onclick = () => {
-                         if(warningText && !confirm(warningText + "\n\n¿Asignar de todos modos?")) return;
+                    btn.onclick = async () => {
+                        if(warningText) {
+                            const confirmed = await showConfirmDialog({
+                                title: "Asignar con advertencias",
+                                message: `${warningText.replace(/\n/g, "<br>")}<br><br>¿Asignar de todos modos?`
+                            });
+                            if(!confirmed) return;
+                        }
                         this.commitChange(() => { shift.employeeId = emp.id; });
                         wrap.remove();
                     };
@@ -1508,7 +1545,7 @@ export const ScheduleManager = {
         f.appendChild(create("button", { className:"btn", textContent:"Guardar", onClick: () => {
             const newStart = Number(startSelect.value);
             const newEnd = Number(endSelect.value);
-            if (newEnd <= newStart) { alert("Fin debe ser mayor a Inicio"); return; }
+            if (newEnd <= newStart) { showToast("Fin debe ser mayor a Inicio", "warning"); return; }
 
             this.commitChange(() => {
                 shift.role = roleSelect.value;
@@ -1522,6 +1559,21 @@ export const ScheduleManager = {
 
         wrap.appendChild(box);
         document.body.appendChild(wrap);
+    },
+
+    getDayRestrictionInfo(employee, shiftDate, shiftDateString) {
+        if (!employee) return { blocked: false, reason: '' };
+
+        if (isDateInSanctionPeriod(shiftDate, employee.sanctions)) {
+            return { blocked: true, reason: 'Licencia activa' };
+        }
+
+        const hasFullDayException = (employee.exceptions || []).some(ex => ex.date === shiftDateString && !ex.start && !ex.end);
+        if (hasFullDayException) {
+            return { blocked: true, reason: 'Excepción de día completo' };
+        }
+
+        return { blocked: false, reason: '' };
     },
 
     renderScheduleList() {
@@ -1614,6 +1666,19 @@ export const ScheduleManager = {
 
             for (let dayIndex = 0; dayIndex < 7; dayIndex++) {
                 const dayCell = create("td", { dataset: { day: dayIndex } });
+                const shiftDate = new Date(weekMonday);
+                shiftDate.setDate(weekMonday.getDate() + dayIndex);
+                const shiftDateString = toISODateString(shiftDate);
+
+                const restrictionInfo = this.getDayRestrictionInfo(emp, shiftDate, shiftDateString);
+                let warningContainer = null;
+                if (restrictionInfo.blocked) {
+                    dayCell.classList.add("warning-cell");
+                    warningContainer = create("div", { className: "warning-cell-content", title: restrictionInfo.reason });
+                    warningContainer.innerHTML = `<div>⚠️ No disponible</div><span>${restrictionInfo.reason}</span>`;
+                    dayCell.appendChild(warningContainer);
+                }
+
                 const dayShifts = (schedule[dayIndex] || []).filter(s => s.employeeId === emp.id);
                 if (dayShifts.length > 0) {
                     const shiftsContainer = create("div", { className: "shifts-container" });
@@ -1644,14 +1709,10 @@ export const ScheduleManager = {
                         }
                         shiftDiv.innerHTML = shiftText;
 
-                        // Sanction conflict visual
-                        const weekMonday = new Date(state.activeWeek + "T12:00:00Z");
-                        const shiftDate = new Date(weekMonday);
-                        shiftDate.setDate(shiftDate.getDate() + dayIndex);
-
-                        if (isDateInSanctionPeriod(shiftDate, emp.sanctions) && !shift.replacement) {
+                        // Day restriction visual
+                        if (restrictionInfo.blocked && !shift.replacement) {
                             shiftDiv.style.border = `2px solid var(--c-danger)`;
-                            shiftDiv.title = 'Conflicto con sanción/licencia';
+                            shiftDiv.title = restrictionInfo.reason;
                         }
 
                         shiftDiv.addEventListener('dragstart', (e) => {
@@ -1668,7 +1729,11 @@ export const ScheduleManager = {
 
                         shiftsContainer.appendChild(shiftDiv);
                     });
-                    dayCell.appendChild(shiftsContainer);
+                    if (warningContainer) {
+                        warningContainer.appendChild(shiftsContainer);
+                    } else {
+                        dayCell.appendChild(shiftsContainer);
+                    }
                 }
                 this.addDropListeners(dayCell);
                 row.appendChild(dayCell);
@@ -1800,7 +1865,7 @@ export const ScheduleManager = {
         setTimeout(() => document.addEventListener('click', closeListener), 0);
     },
 
-    handleSlotClick(shift, slotIndex) {
+    async handleSlotClick(shift, slotIndex) {
         const state = store.getState();
         const emp = shift.employeeId ? state.employees.find(e => e.id === shift.employeeId) : null;
         const dayIndex = typeof state.activeDay === 'number' ? state.activeDay : 0;
@@ -1826,7 +1891,11 @@ export const ScheduleManager = {
             const isUnavailable = emp && isSlotUnavailable(emp, slotIndex, state.activeWeek, dayIndex);
             if (isUnavailable) {
                 const confirmMessage = 'Esta celda está marcada como no disponible para este empleado. ¿Querés continuar de todos modos?';
-                if (!confirm(confirmMessage)) return;
+                const confirmed = await showConfirmDialog({
+                    title: "Celda no disponible",
+                    message: confirmMessage
+                });
+                if (!confirmed) return;
             }
 
             this.commitChange(() => {

--- a/src/modules/StatsManager.js
+++ b/src/modules/StatsManager.js
@@ -4,6 +4,7 @@ import { DAYS, SLOTS } from '../config.js';
 import { toISODateString, getMonday } from '../utils/date.js';
 import { ScheduleManager } from './ScheduleManager.js';
 import { DataManager } from '../services/DataManager.js';
+import { showToast } from '../utils/feedback.js';
 
 export const StatsManager = {
     init() {
@@ -310,7 +311,7 @@ export const StatsManager = {
                 await this.processAndCompareClockIns(json);
             } catch (err) {
                 console.error(err);
-                alert("Error procesando fichero.");
+                showToast("Error procesando fichero.", "error");
             }
         };
         reader.readAsArrayBuffer(file);

--- a/src/services/DataManager.js
+++ b/src/services/DataManager.js
@@ -1,6 +1,7 @@
 import { store, getActiveSchedule } from '../store/Store.js';
 import { ROLES, setRoles, DEFAULT_ROLES } from '../config.js';
 import { getDb, initFirebase } from './firebase.js';
+import { showToast } from '../utils/feedback.js';
 export { getDb } from './firebase.js';
 import {
     legacyEmployeesRef,
@@ -225,7 +226,7 @@ export const DataManager = {
             console.log("State saved.");
         } catch (error) {
             console.error("Error saving state:", error);
-            alert("Error guardando: " + error.message);
+            showToast("Error guardando: " + error.message, "error");
         }
     },
 

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -1,6 +1,7 @@
 import { store } from '../store/Store.js';
 import { initFirebase, getAuth, getDb } from './firebase.js';
 import { userDocRef } from './firestoreRefs.js';
+import { showToast } from '../utils/feedback.js';
 
 const STORAGE_KEY = 'activeStoreId';
 
@@ -93,7 +94,7 @@ export const SessionService = {
           const profileSnap = await userDocRef(user.uid).get();
           if (!profileSnap.exists) {
             console.error('Usuario sin permisos');
-            alert('Usuario sin permisos.');
+            showToast('Usuario sin permisos.', 'error');
             await auth.signOut();
             window.location.href = 'index.html';
             return;
@@ -147,7 +148,7 @@ export const SessionService = {
           } else if (allowedStores.length > 1) {
             createSelectionUI(allowedStores, handleSelect, logout);
           } else {
-            alert('No hay locales habilitados para este usuario.');
+            showToast('No hay locales habilitados para este usuario.', 'error');
             reject(new Error('Sin locales')); // will show overlay still
           }
         } catch (err) {

--- a/src/utils/feedback.js
+++ b/src/utils/feedback.js
@@ -1,0 +1,132 @@
+import { create } from './dom.js';
+
+let toastContainer = null;
+let activeModal = null;
+
+function ensureToastContainer() {
+    if (toastContainer) return toastContainer;
+    toastContainer = create('div', { className: 'toast-container', id: 'toast-container' });
+    document.body.appendChild(toastContainer);
+    return toastContainer;
+}
+
+function clearActiveModal() {
+    if (activeModal) {
+        activeModal.remove();
+        activeModal = null;
+    }
+}
+
+export function showToast(message, type = 'info', duration = 4000) {
+    if (!message) return;
+    const container = ensureToastContainer();
+    const toast = create('div', { className: `toast toast-${type}` });
+    const text = create('span', { className: 'toast-message', textContent: message });
+    const closeBtn = create('button', { className: 'toast-close', textContent: '×', title: 'Cerrar' });
+
+    closeBtn.onclick = () => {
+        toast.classList.add('toast-hide');
+        setTimeout(() => toast.remove(), 150);
+    };
+
+    toast.appendChild(text);
+    toast.appendChild(closeBtn);
+    container.appendChild(toast);
+
+    setTimeout(() => {
+        if (toast.isConnected) {
+            toast.classList.add('toast-hide');
+            setTimeout(() => toast.remove(), 150);
+        }
+    }, duration);
+}
+
+export function showAlertDialog({ title = 'Aviso', message = '', confirmText = 'Entendido' } = {}) {
+    return showDialog({
+        title,
+        message,
+        confirmText,
+        cancelText: null
+    });
+}
+
+export function showConfirmDialog({
+    title = 'Confirmar',
+    message = '',
+    confirmText = 'Confirmar',
+    cancelText = 'Cancelar'
+} = {}) {
+    return showDialog({
+        title,
+        message,
+        confirmText,
+        cancelText
+    });
+}
+
+export function showDialog({ title, message, confirmText, cancelText }) {
+    clearActiveModal();
+
+    return new Promise((resolve) => {
+        const overlay = create('div', { className: 'modal-overlay feedback-modal' });
+        const modal = create('div', { className: 'modal-content feedback-modal-content' });
+
+        const header = create('div', { className: 'feedback-modal-header' });
+        header.appendChild(create('h3', { textContent: title || '' }));
+        const closeBtn = create('button', { className: 'btn icon-btn', textContent: '×', title: 'Cerrar' });
+        closeBtn.onclick = () => {
+            cleanup();
+            resolve(false);
+        };
+        header.appendChild(closeBtn);
+
+        const body = create('div', { className: 'feedback-modal-body' });
+        body.appendChild(create('p', { innerHTML: message.replace(/\n/g, '<br>') }));
+
+        const footer = create('div', { className: 'feedback-modal-footer' });
+        const buttons = [];
+
+        if (cancelText) {
+            const cancelBtn = create('button', { className: 'btn secondary', textContent: cancelText });
+            cancelBtn.onclick = () => {
+                cleanup();
+                resolve(false);
+            };
+            buttons.push(cancelBtn);
+        }
+
+        const confirmBtn = create('button', { className: 'btn', textContent: confirmText || 'Aceptar' });
+        confirmBtn.onclick = () => {
+            confirmBtn.disabled = true;
+            buttons.forEach(b => b.disabled = true);
+            confirmBtn.textContent = 'Confirmando...';
+            setTimeout(() => {
+                cleanup();
+                resolve(true);
+            }, 150);
+        };
+        buttons.push(confirmBtn);
+
+        buttons.forEach(btn => footer.appendChild(btn));
+
+        modal.appendChild(header);
+        modal.appendChild(body);
+        modal.appendChild(footer);
+        overlay.appendChild(modal);
+
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay && cancelText) {
+                cleanup();
+                resolve(false);
+            }
+        });
+
+        const cleanup = () => {
+            if (overlay && overlay.isConnected) overlay.remove();
+            activeModal = null;
+        };
+
+        activeModal = overlay;
+        document.body.appendChild(overlay);
+    });
+}

--- a/style.css
+++ b/style.css
@@ -610,6 +610,83 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   min-width: 300px;
   max-width: 500px; /* Default max-width */
 }
+.feedback-modal {
+  background: rgba(0, 0, 0, 0.45);
+  padding: 12px;
+}
+.feedback-modal-content {
+  width: min(520px, 92vw);
+  border: 1px solid var(--border);
+}
+.feedback-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.feedback-modal-header h3 {
+  margin: 0;
+  font-size: 16px;
+}
+.feedback-modal-body {
+  padding: 16px;
+  color: var(--ink-base);
+  line-height: 1.4;
+}
+.feedback-modal-body p {
+  margin: 0;
+}
+.feedback-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px 16px;
+}
+.toast-container {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1100;
+}
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--card);
+  color: var(--ink-base);
+  padding: 10px 12px;
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.15);
+  border: 1px solid var(--border);
+  min-width: 260px;
+  max-width: 360px;
+  animation: toast-in 0.2s ease-out;
+}
+.toast-success { border-color: #16a34a33; }
+.toast-error { border-color: #dc262633; }
+.toast-warning { border-color: #f9731633; }
+.toast-info { border-color: #2563eb33; }
+.toast-message { flex: 1; }
+.toast-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 16px;
+  cursor: pointer;
+}
+.toast-hide {
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
 #weekly-summary-modal .modal-content {
   max-width: 1200px; /* Wider for summary */
@@ -982,6 +1059,43 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
 .schedule-list-shift:hover {
   transform: scale(1.03);
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+.warning-cell {
+  position: relative;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(251, 191, 36, 0.16),
+    rgba(251, 191, 36, 0.16) 10px,
+    rgba(251, 191, 36, 0.28) 10px,
+    rgba(251, 191, 36, 0.28) 20px
+  );
+  border: 2px solid rgba(234, 179, 8, 0.7) !important;
+  color: #7c2d12;
+}
+.warning-cell .warning-cell-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+  justify-content: center;
+  min-height: 60px;
+  font-weight: 600;
+  text-align: center;
+}
+.warning-cell .warning-cell-content span {
+  font-size: 12px;
+  line-height: 1.3;
+}
+.dark-mode .warning-cell {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(202, 138, 4, 0.28),
+    rgba(202, 138, 4, 0.28) 10px,
+    rgba(234, 179, 8, 0.22) 10px,
+    rgba(234, 179, 8, 0.22) 20px
+  );
+  border-color: rgba(234, 179, 8, 0.8) !important;
+  color: #fef08a;
 }
 
 /* Shift Context Menu */


### PR DESCRIPTION
## Summary
- replace all browser alerts/confirmations with centralized in-app toasts and confirmation modals for consistent UX in light/dark modes
- redesign schedule list warning cells to cover the full cell with a caution stripe pattern and clear messaging for licenses/exceptions
- keep exception creation conflict checks while surfacing them through the new dialog/toast system

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0fd05b24832d95d069ff21df4724)