### PR TITLE
Validate availability conflicts on edits

### DIFF
--- a/manager.html
+++ b/manager.html
@@ -190,12 +190,16 @@
                                   <span>Menor</span>
                                 </label>
                                 <label class="pill-toggle export-field">
-                                  <input type="checkbox" value="availability" checked>
-                                  <span>Disponibilidad (resumen)</span>
+                                  <input type="checkbox" value="availabilityByDay">
+                                  <span>Disponibilidad por día</span>
                                 </label>
                                 <label class="pill-toggle export-field">
                                   <input type="checkbox" value="exceptions">
                                   <span>Excepciones</span>
+                                </label>
+                                <label class="pill-toggle export-field">
+                                  <input type="checkbox" value="exceptionsDetailed">
+                                  <span>Excepciones (detalle)</span>
                                 </label>
                                 <label class="pill-toggle export-field">
                                   <input type="checkbox" value="sanctions">

--- a/manager.html
+++ b/manager.html
@@ -18,7 +18,7 @@
   </div>
   <div class="bar">
     <div class="bar-inner">
-        <div class="row main-bar-row">
+                <button id="btn-view-requests" class="dropdown-item">Solicitudes</button>
           <div class="row main-bar-left">
             <div id="main-menu" class="main-menu">
               <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>

--- a/manager.html
+++ b/manager.html
@@ -19,14 +19,11 @@
   <div class="bar">
     <div class="bar-inner">
                 <button id="btn-view-requests" class="dropdown-item">Solicitudes</button>
-        <div class="header-center">
-          <div id="week-selector-container" class="row week-selector">
-              <button id="btn-lock-week" class="btn secondary">🔓</button>
-              <button id="btn-prev-week" class="btn secondary">◄</button>
-              <button id="week-display" class="btn secondary"></button>
-              <button id="btn-next-week" class="btn secondary">►</button>
-          </div>
-          <div id="day-title" class="day-title"></div>
+        <div id="week-selector-container" class="row week-selector">
+            <button id="btn-lock-week" class="btn secondary">🔓</button>
+            <button id="btn-prev-week" class="btn secondary">◄</button>
+            <button id="week-display" class="btn secondary"></button>
+            <button id="btn-next-week" class="btn secondary">►</button>
               <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
               <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
               <button id="btn-weekly-summary" class="btn secondary main-menu-btn">Resumen semanal</button>

--- a/manager.html
+++ b/manager.html
@@ -18,9 +18,8 @@
   </div>
   <div class="bar">
     <div class="bar-inner">
-      <div class="row">
-        <h1 style="font-size: 1.1em; white-space: nowrap;">Planificador de Horarios</h1>
-        <div id="main-menu" style="margin-left: 16px;">
+      <div class="row main-bar-row">
+        <div id="main-menu" class="main-menu">
           <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
           <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
           <button id="btn-view-templates" class="btn secondary main-menu-btn">Plantillas</button>
@@ -32,13 +31,13 @@
           <button id="btn-planilla-turno" class="btn secondary main-menu-btn">Planilla de Turno</button>
           <button id="btn-view-options" class="btn secondary main-menu-btn">Opciones</button>
         </div>
-        <div id="week-selector-container" class="row" style="margin-left: 16px;">
+        <div id="week-selector-container" class="row week-selector">
             <button id="btn-lock-week" class="btn secondary">🔓</button>
             <button id="btn-prev-week" class="btn secondary">◄</button>
             <button id="week-display" class="btn secondary"></button>
             <button id="btn-next-week" class="btn secondary">►</button>
         </div>
-        <div class="dropdown" style="margin-left: 8px;">
+        <div class="dropdown actions-dropdown">
           <button id="btn-actions" class="btn secondary">Acciones ▾</button>
           <div id="actions-dropdown" class="dropdown-content">
             <button id="btnPrint" class="dropdown-item">Imprimir</button>
@@ -46,9 +45,12 @@
             <button id="btn-auto-assign" class="dropdown-item">Auto-completar Semana</button>
             <div class="dropdown-divider"></div>
             <button id="btn-advanced-import-export" class="dropdown-item">Importar/Exportar (Avanzado)</button>
+            <div class="dropdown-divider"></div>
+            <button id="change-store-inline" class="dropdown-item">Cambiar local</button>
+            <button id="logout-inline" class="dropdown-item">Salir</button>
           </div>
         </div>
-        <button id="btn-dark-mode" class="btn secondary" style="margin-left:auto;">🌙</button>
+        <button id="btn-dark-mode" class="btn secondary">🌙</button>
       </div>
     </div>
   </div>

--- a/manager.html
+++ b/manager.html
@@ -18,25 +18,25 @@
   </div>
   <div class="bar">
     <div class="bar-inner">
-      <div class="row main-bar-row">
-        <div class="row main-bar-left">
-          <div id="main-menu" class="main-menu">
-            <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
-            <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
-            <button id="btn-schedule-list" class="btn secondary main-menu-btn">Listado</button>
-            <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
-            <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
-            <div class="dropdown more-dropdown">
-              <button id="btn-more" class="btn secondary">Más ▾</button>
-              <div id="more-dropdown" class="dropdown-content">
-                <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
-                <button id="btn-view-francos" class="dropdown-item">Francos</button>
-                <button id="btn-weekly-summary" class="dropdown-item">Resumen semanal</button>
-                <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
-                <button id="btn-view-options" class="dropdown-item">Opciones</button>
+        <div class="row main-bar-row">
+          <div class="row main-bar-left">
+            <div id="main-menu" class="main-menu">
+              <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
+              <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
+              <button id="btn-schedule-list" class="btn secondary main-menu-btn">Listado</button>
+              <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
+              <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
+              <button id="btn-weekly-summary" class="btn secondary main-menu-btn">Resumen semanal</button>
+              <div class="dropdown more-dropdown">
+                <button id="btn-more" class="btn secondary">Más ▾</button>
+                <div id="more-dropdown" class="dropdown-content">
+                  <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
+                  <button id="btn-view-francos" class="dropdown-item">Francos</button>
+                  <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
+                  <button id="btn-view-options" class="dropdown-item">Opciones</button>
+                </div>
               </div>
             </div>
-          </div>
         </div>
 
         <div id="week-selector-container" class="row week-selector">
@@ -47,6 +47,10 @@
         </div>
 
         <div class="row main-bar-right">
+          <div id="session-banner" class="session-banner">
+            <span class="pill" id="session-user-label"></span>
+            <span class="pill pill-neutral" id="session-store-label"></span>
+          </div>
           <div class="dropdown actions-dropdown">
             <button id="btn-actions" class="btn secondary">Acciones ▾</button>
             <div id="actions-dropdown" class="dropdown-content">

--- a/manager.html
+++ b/manager.html
@@ -19,11 +19,14 @@
   <div class="bar">
     <div class="bar-inner">
                 <button id="btn-view-requests" class="dropdown-item">Solicitudes</button>
-          <div class="row main-bar-left">
-            <div id="main-menu" class="main-menu">
-              <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
-              <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
-              <button id="btn-schedule-list" class="btn secondary main-menu-btn">Listado</button>
+        <div class="header-center">
+          <div id="week-selector-container" class="row week-selector">
+              <button id="btn-lock-week" class="btn secondary">🔓</button>
+              <button id="btn-prev-week" class="btn secondary">◄</button>
+              <button id="week-display" class="btn secondary"></button>
+              <button id="btn-next-week" class="btn secondary">►</button>
+          </div>
+          <div id="day-title" class="day-title"></div>
               <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
               <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
               <button id="btn-weekly-summary" class="btn secondary main-menu-btn">Resumen semanal</button>

--- a/manager.html
+++ b/manager.html
@@ -19,45 +19,49 @@
   <div class="bar">
     <div class="bar-inner">
       <div class="row main-bar-row">
-        <div id="main-menu" class="main-menu">
-          <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
-          <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
-          <button id="btn-schedule-list" class="btn secondary main-menu-btn">Listado</button>
-          <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
-          <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
+        <div class="row main-bar-left">
+          <div id="main-menu" class="main-menu">
+            <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
+            <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
+            <button id="btn-schedule-list" class="btn secondary main-menu-btn">Listado</button>
+            <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
+            <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
+            <div class="dropdown more-dropdown">
+              <button id="btn-more" class="btn secondary">Más ▾</button>
+              <div id="more-dropdown" class="dropdown-content">
+                <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
+                <button id="btn-view-francos" class="dropdown-item">Francos</button>
+                <button id="btn-weekly-summary" class="dropdown-item">Resumen semanal</button>
+                <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
+                <button id="btn-view-options" class="dropdown-item">Opciones</button>
+              </div>
+            </div>
+          </div>
         </div>
+
         <div id="week-selector-container" class="row week-selector">
             <button id="btn-lock-week" class="btn secondary">🔓</button>
             <button id="btn-prev-week" class="btn secondary">◄</button>
             <button id="week-display" class="btn secondary"></button>
             <button id="btn-next-week" class="btn secondary">►</button>
         </div>
-        <div class="dropdown more-dropdown">
-          <button id="btn-more" class="btn secondary">Más ▾</button>
-          <div id="more-dropdown" class="dropdown-content">
-            <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
-            <button id="btn-view-francos" class="dropdown-item">Francos</button>
-            <button id="btn-weekly-summary" class="dropdown-item">Resumen semanal</button>
-            <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
-            <button id="btn-view-options" class="dropdown-item">Opciones</button>
-            <div class="dropdown-divider"></div>
-            <button id="btn-dark-mode" class="dropdown-item">Tema</button>
+
+        <div class="row main-bar-right">
+          <div class="dropdown actions-dropdown">
+            <button id="btn-actions" class="btn secondary">Acciones ▾</button>
+            <div id="actions-dropdown" class="dropdown-content">
+              <button id="btnPrint" class="dropdown-item">Imprimir</button>
+              <button id="btn-import-text" class="dropdown-item">Importar desde texto</button>
+              <button id="btn-auto-assign" class="dropdown-item">Auto-completar Semana</button>
+              <div class="dropdown-divider"></div>
+              <button id="btn-advanced-import-export" class="dropdown-item">Importar/Exportar (Avanzado)</button>
+              <div class="dropdown-divider"></div>
+              <button id="change-store-inline" class="dropdown-item">Cambiar local</button>
+              <button id="logout-inline" class="dropdown-item">Salir</button>
+            </div>
           </div>
+          <button id="btn-dark-mode" class="btn secondary">🌙</button>
         </div>
-        <div class="dropdown actions-dropdown">
-          <button id="btn-actions" class="btn secondary">Acciones ▾</button>
-          <div id="actions-dropdown" class="dropdown-content">
-            <button id="btnPrint" class="dropdown-item">Imprimir</button>
-            <button id="btn-import-text" class="dropdown-item">Importar desde texto</button>
-            <button id="btn-auto-assign" class="dropdown-item">Auto-completar Semana</button>
-            <div class="dropdown-divider"></div>
-            <button id="btn-advanced-import-export" class="dropdown-item">Importar/Exportar (Avanzado)</button>
-            <div class="dropdown-divider"></div>
-            <button id="change-store-inline" class="dropdown-item">Cambiar local</button>
-            <button id="logout-inline" class="dropdown-item">Salir</button>
-          </div>
-        </div>
-        <button id="btn-dark-mode" class="btn secondary">🌙</button>
       </div>
     </div>
   </div>

--- a/manager.html
+++ b/manager.html
@@ -22,20 +22,27 @@
         <div id="main-menu" class="main-menu">
           <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
           <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
-          <button id="btn-view-templates" class="btn secondary main-menu-btn">Plantillas</button>
           <button id="btn-schedule-list" class="btn secondary main-menu-btn">Listado</button>
-          <button id="btn-view-francos" class="btn secondary main-menu-btn">Francos</button>
           <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
           <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
-          <button id="btn-weekly-summary" class="btn secondary main-menu-btn">Resumen semanal</button>
-          <button id="btn-planilla-turno" class="btn secondary main-menu-btn">Planilla de Turno</button>
-          <button id="btn-view-options" class="btn secondary main-menu-btn">Opciones</button>
         </div>
         <div id="week-selector-container" class="row week-selector">
             <button id="btn-lock-week" class="btn secondary">🔓</button>
             <button id="btn-prev-week" class="btn secondary">◄</button>
             <button id="week-display" class="btn secondary"></button>
             <button id="btn-next-week" class="btn secondary">►</button>
+        </div>
+        <div class="dropdown more-dropdown">
+          <button id="btn-more" class="btn secondary">Más ▾</button>
+          <div id="more-dropdown" class="dropdown-content">
+            <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
+            <button id="btn-view-francos" class="dropdown-item">Francos</button>
+            <button id="btn-weekly-summary" class="dropdown-item">Resumen semanal</button>
+            <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
+            <button id="btn-view-options" class="dropdown-item">Opciones</button>
+            <div class="dropdown-divider"></div>
+            <button id="btn-dark-mode" class="dropdown-item">Tema</button>
+          </div>
         </div>
         <div class="dropdown actions-dropdown">
           <button id="btn-actions" class="btn secondary">Acciones ▾</button>

--- a/src/app_main.js
+++ b/src/app_main.js
@@ -56,6 +56,11 @@ async function init() {
     // Initial Load
     await DataManager.loadState(store.getState().activeStoreId);
 
+    // Try to persist pending cambios antes de salir/cerrar pestaña
+    window.addEventListener('beforeunload', () => {
+        DataManager.saveState();
+    });
+
     document.addEventListener('store-changed', async (event) => {
         const storeId = event.detail?.storeId;
         if (!storeId) return;

--- a/src/modules/EmployeeManager.js
+++ b/src/modules/EmployeeManager.js
@@ -1,10 +1,11 @@
 import { el, create, clear } from '../utils/dom.js';
 import { store } from '../store/Store.js';
 import { DataManager } from '../services/DataManager.js';
-import { ROLES, SLOTS } from '../config.js';
+import { ROLES, SLOTS, DAYS } from '../config.js';
 import { storeEmployeesRef, legacyEmployeesRef } from '../services/firestoreRefs.js';
 import { getMonday, toISODateString } from '../utils/date.js';
 import { showToast, showConfirmDialog, showAlertDialog } from '../utils/feedback.js';
+import { checkEmployeeAvailability } from '../utils/rules.js';
 
 const EXPORT_FIELD_CONFIG = {
     name: { label: 'Nombre completo', getter: (e) => e.name || '' },
@@ -15,8 +16,9 @@ const EXPORT_FIELD_CONFIG = {
     stars: { label: 'Roles/Estrellas', getter: (e) => (e.stars || []).join(', ') || 'Sin roles' },
     allStar: { label: 'All Star', getter: (e) => e.isAllStar ? 'Sí' : 'No' },
     minor: { label: 'Menor', getter: (e) => e.isMinor ? 'Sí' : 'No' },
-    availability: { label: 'Disponibilidad (resumen)', getter: (e, ctx) => ctx.getAvailabilitySummary(e) },
+    availabilityByDay: { label: 'Disponibilidad (por día)', getter: (e, ctx) => ctx.getAvailabilityByDay(e) },
     exceptions: { label: 'Excepciones', getter: (e) => `${(e.exceptions || []).length}` },
+    exceptionsDetailed: { label: 'Excepciones (detalle)', getter: (e, ctx) => ctx.getExceptionsDetail(e) },
     sanctions: { label: 'Licencias / sanciones', getter: (e) => `${(e.sanctions || []).length}` },
     priority: { label: 'Prioridad', getter: (e, ctx) => ctx.priorityLabel(e.priority) }
 };
@@ -488,6 +490,12 @@ export const EmployeeManager = {
         const stack = create("div", { className: "stack" });
         stack.appendChild(create("strong", { textContent: "Disponibilidad Semanal" }));
 
+        const conflicts = this.findAvailabilityConflicts(emp);
+        if (conflicts.length > 0) {
+            stack.appendChild(create("div", { className: "warning-text", innerHTML: conflicts.join("<br>") }));
+            stack.appendChild(create("div", { className: "hr" }));
+        }
+
         const DAYS = ["Lunes","Martes","Miércoles","Jueves","Viernes","Sábado","Domingo"];
         import('../config.js').then(({ SLOTS }) => {
             if (!SLOTS) {
@@ -579,7 +587,17 @@ export const EmployeeManager = {
             content.appendChild(create("div", { className: "hr" }));
 
             const footer = create("div", { style: { textAlign: "right" } });
-            footer.appendChild(create("button", { className: "btn", textContent: "Guardar y Cerrar", onClick: () => {
+            footer.appendChild(create("button", { className: "btn", textContent: "Guardar y Cerrar", onClick: async () => {
+                const newConflicts = this.findAvailabilityConflicts(emp);
+                if (newConflicts.length > 0) {
+                    const proceed = await showConfirmDialog({
+                        title: "Conflictos con turnos asignados",
+                        message: `${newConflicts.join("<br>")}<br><br>¿Guardar de todos modos?`,
+                        confirmText: "Guardar igualmente",
+                        cancelText: "Cancelar"
+                    });
+                    if (!proceed) return;
+                }
                 DataManager.saveState();
                 store.setState({ activeDetailEmployeeId: null });
                 this.renderList();
@@ -598,6 +616,12 @@ export const EmployeeManager = {
 
         const panel = create("div", { className: "employee-detail-panel" });
         const list = create("div", { className: "stack" });
+
+        const conflicts = this.findAvailabilityConflicts(emp);
+        if (conflicts.length > 0) {
+            panel.appendChild(create("div", { className: "warning-text", innerHTML: conflicts.join("<br>") }));
+            panel.appendChild(create("div", { className: "hr" }));
+        }
 
         (emp.exceptions || []).forEach(ex => {
             const row = create("div", { className: "row", style: { justifyContent: "space-between" } });
@@ -620,6 +644,10 @@ export const EmployeeManager = {
 
         const addBtn = create("button", { className: "btn", textContent: "Añadir", onClick: async () => {
             if(dateInput.value) {
+                const selectedDate = new Date(`${dateInput.value}T00:00:00`);
+                const today = new Date();
+                today.setHours(0, 0, 0, 0);
+
                 if(!emp.exceptions) emp.exceptions = [];
                 const newEx = {
                     date: dateInput.value,
@@ -634,23 +662,37 @@ export const EmployeeManager = {
                 }
 
                 const conflictShifts = await this.getEmployeeShiftsForDate(emp.id, dateInput.value);
-                if (conflictShifts.length > 0) {
+                if (conflictShifts.length > 0 && selectedDate >= today) {
                     const summary = conflictShifts.map(s => this.formatShiftRange(s)).filter(Boolean).join(' | ');
                     const promptText = [
-                        `⚠️ ${emp.name} ya tiene ${conflictShifts.length === 1 ? 'un turno' : `${conflictShifts.length} turnos`} asignado${conflictShifts.length === 1 ? '' : 's'} ese día.`,
-                        summary ? `Horarios: ${summary}.` : '',
-                        '',
-                        '¿Querés registrar la excepción igualmente?'
-                    ].filter(Boolean).join('\n');
+                        `${emp.name} ya tiene ${conflictShifts.length === 1 ? 'un turno' : `${conflictShifts.length} turnos`} asignado${conflictShifts.length === 1 ? '' : 's'} ese día.`,
+                        summary ? `Horarios: ${summary}.` : ''
+                    ].filter(Boolean).join('<br>');
                     const proceed = await showConfirmDialog({
-                        title: "Conflicto de horarios",
-                        message: promptText.replace(/\n/g, "<br>"),
-                        confirmText: "Registrar igualmente"
+                        title: "Conflicto con turnos asignados",
+                        message: `${promptText}<br><br>¿Registrar la excepción igualmente?`,
+                        confirmText: "Registrar igual",
+                        cancelText: "Cancelar"
                     });
                     if (!proceed) return;
                 }
 
                 emp.exceptions.push(newEx);
+
+                const availabilityConflicts = this.findAvailabilityConflicts(emp);
+                if (availabilityConflicts.length > 0) {
+                    const proceedAvail = await showConfirmDialog({
+                        title: "Conflictos con turnos asignados",
+                        message: `${availabilityConflicts.join("<br>")}<br><br>¿Guardar la excepción igualmente?`,
+                        confirmText: "Guardar igual",
+                        cancelText: "Cancelar"
+                    });
+                    if (!proceedAvail) {
+                        emp.exceptions.pop();
+                        return;
+                    }
+                }
+
                 DataManager.saveState();
                 this.renderList();
             } else {
@@ -821,16 +863,100 @@ export const EmployeeManager = {
         return Object.values(availability).some(day => Array.isArray(day) && day.length > 0);
     },
 
-    getAvailabilitySummary(emp) {
-        const daysWithRules = Object.values(emp.availability || {}).filter(day => Array.isArray(day) && day.length > 0).length;
-        const exceptionsCount = (emp.exceptions || []).length;
+    getSlotLabelSafe(value, fallbackSlotIndex, isEnd = false) {
+        if (typeof value === 'string') {
+            const normalized = value.trim().substring(0, 5);
+            const padded = normalized.length === 4 ? `0${normalized}` : normalized;
+            const match = SLOTS.find(s => s.label === padded);
+            if (match) return match.label;
+        }
+        if (typeof fallbackSlotIndex === 'number') {
+            const idx = isEnd ? fallbackSlotIndex + 1 : fallbackSlotIndex;
+            return SLOTS[idx]?.label || '';
+        }
+        return '';
+    },
 
-        if (daysWithRules === 0 && exceptionsCount === 0) return "Sin restricciones cargadas";
+    getAvailabilityByDay(emp) {
+        if (!emp || !emp.availability) return '';
+        const mapRange = (slot) => {
+            const start = this.getSlotLabelSafe(slot.start, slot.startSlot, false) || 'Apertura';
+            const end = this.getSlotLabelSafe(slot.end, slot.endSlot, true) || 'Cierre';
+            return `${start} - ${end}`;
+        };
 
-        const parts = [];
-        if (daysWithRules > 0) parts.push(`${daysWithRules} día${daysWithRules === 1 ? '' : 's'} con disponibilidad`);
-        if (exceptionsCount > 0) parts.push(`${exceptionsCount} excepción${exceptionsCount === 1 ? '' : 'es'}`);
-        return parts.join(" · ");
+        return DAYS.map((dayLabel, idx) => {
+            const dayAvailability = emp.availability[idx] || emp.availability[String(idx)] || [];
+            if (!dayAvailability || dayAvailability.length === 0) return `${dayLabel}: Libre`;
+            const ranges = dayAvailability.map(mapRange).join(' | ');
+            return `${dayLabel}: ${ranges}`;
+        }).join('\n');
+    },
+
+    getExceptionsDetail(emp) {
+        const exceptions = emp?.exceptions || [];
+        if (exceptions.length === 0) return '';
+
+        const formatDateInfo = (dateStr) => {
+            const parsed = new Date(`${dateStr}T12:00:00Z`);
+            const dayIndex = Number.isNaN(parsed.getTime()) ? null : (parsed.getUTCDay() === 0 ? 6 : parsed.getUTCDay() - 1);
+            const dayLabel = dayIndex !== null && DAYS[dayIndex] ? DAYS[dayIndex] : 'Fecha';
+            const isWeekend = dayIndex === 5 || dayIndex === 6;
+            const formatted = `${dayLabel} ${dateStr}`;
+            return { formatted, isWeekend };
+        };
+
+        const describeException = (ex) => {
+            const { formatted, isWeekend } = formatDateInfo(ex.date);
+            if (!ex.start && !ex.end) {
+                return `${formatted}: Día completo${isWeekend ? ' (fin de semana)' : ''}`;
+            }
+            const start = this.getSlotLabelSafe(ex.start, ex.startSlot, false);
+            const end = this.getSlotLabelSafe(ex.end, ex.endSlot, true);
+            const range = start && end ? `${start} - ${end}` : 'Parcial';
+            return `${formatted}: Parcial ${range}${isWeekend ? ' (fin de semana)' : ''}`;
+        };
+
+        return exceptions.map(describeException).join('\n');
+    },
+
+    getShiftDateFromWeekDay(weekId, dayIndex) {
+        const monday = new Date(`${weekId}T12:00:00.000Z`);
+        const date = new Date(monday);
+        date.setUTCDate(monday.getUTCDate() + dayIndex);
+        return date;
+    },
+
+    findAvailabilityConflicts(emp) {
+        if (!emp) return [];
+
+        const schedules = store.getState().schedules || {};
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const conflicts = [];
+
+        Object.entries(schedules).forEach(([weekId, weekSchedule]) => {
+            if (!weekSchedule) return;
+            for (let dayIndex = 0; dayIndex < 7; dayIndex++) {
+                const dayShifts = weekSchedule[dayIndex] || [];
+                dayShifts.filter(s => s.employeeId === emp.id).forEach(shift => {
+                    const shiftDate = this.getShiftDateFromWeekDay(weekId, dayIndex);
+                    const localShiftDate = new Date(shiftDate);
+                    localShiftDate.setHours(0, 0, 0, 0);
+
+                    if (localShiftDate < today) return; // Skip past weeks/days
+
+                    const availabilityCheck = checkEmployeeAvailability(emp, shift, weekId, dayIndex);
+                    if (!availabilityCheck.isAvailable) {
+                        const startLabel = SLOTS[shift.startSlot]?.label || '';
+                        const endLabel = SLOTS[shift.endSlot + 1]?.label || '02:00';
+                        conflicts.push(`Conflicto el ${DAYS[dayIndex]} ${shiftDate.getUTCDate()}/${shiftDate.getUTCMonth() + 1}: Turno de ${shift.role} (${startLabel} - ${endLabel}) choca con la nueva disponibilidad/excepción.`);
+                    }
+                });
+            }
+        });
+
+        return [...new Set(conflicts)];
     },
 
     getSelectedExportFields() {

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -243,7 +243,6 @@ export const ScheduleManager = {
         this.renderLegend();
         this.updateLockUI();
         this.updateWeekDisplay();
-        this.updateDayTitle();
         this.renderWeeklyStats();
 
         // Ensure this method exists before calling

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -243,6 +243,7 @@ export const ScheduleManager = {
         this.renderLegend();
         this.updateLockUI();
         this.updateWeekDisplay();
+        this.updateDayTitle();
         this.renderWeeklyStats();
 
         // Ensure this method exists before calling

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -661,6 +661,37 @@ export const ScheduleManager = {
         schedule[d] = schedule[d] || [];
     },
 
+    validateShiftForEmployee(employee, shift, dayIndex, weekId, shiftsToIgnore = []) {
+        if (!employee) return { pass: false, message: "Empleado no encontrado." };
+        if (!shift && shift !== 0) return { pass: false, message: "Turno no válido." };
+
+        if (shift.ignoreRestrictions) return { pass: true, message: "" };
+
+        const shiftDate = new Date(`${weekId}T12:00:00.000Z`);
+        shiftDate.setUTCDate(shiftDate.getUTCDate() + dayIndex);
+
+        if (isDateInSanctionPeriod(shiftDate, employee.sanctions)) {
+            return { pass: false, message: "El empleado tiene una licencia activa." };
+        }
+
+        if (employee.isMinor && shift.endSlot > MAX_SLOT_FOR_MINOR) {
+            return { pass: false, message: "El empleado es menor y no puede trabajar en este horario." };
+        }
+
+        const overlapCheck = checkShiftOverlap(employee.id, shift, dayIndex, shiftsToIgnore);
+        if (!overlapCheck.pass) return overlapCheck;
+
+        const restCheck = checkRestTime(employee.id, shift, weekId, dayIndex);
+        if (!restCheck.pass) return restCheck;
+
+        const availabilityCheck = checkEmployeeAvailability(employee, shift, weekId, dayIndex);
+        if (!availabilityCheck.isAvailable) {
+            return { pass: false, message: availabilityCheck.reason };
+        }
+
+        return { pass: true, message: "" };
+    },
+
     commitChange(action) {
         const currentSchedule = getActiveSchedule();
         historyManager.push(currentSchedule);
@@ -1768,48 +1799,72 @@ export const ScheduleManager = {
             const sourceShift = schedule[sourceDayIndex]?.find(s => s.id === sourceShiftId);
             if (!sourceShift) return;
 
-            this.commitChange(() => {
-                // Scenario 1: Unassign
-                if (targetEmployeeId === 'unassigned') {
-                    if (!sourceShift.employeeId) return;
+            const state = store.getState();
+            const weekId = state.activeWeek;
+            this.ensureDay(sourceDayIndex);
+            this.ensureDay(targetDayIndex);
+
+            // Scenario 1: Unassign
+            if (targetEmployeeId === 'unassigned') {
+                if (!sourceShift.employeeId) return;
+                this.commitChange(() => {
                     sourceShift.employeeId = null;
+                });
+                return;
+            }
+
+            const targetEmployee = state.employees.find(e => e.id === targetEmployeeId);
+            if (!targetEmployee) return;
+
+            // Scenario 2: Swap
+            if (targetShiftElement) {
+                const targetShiftId = targetShiftElement.dataset.shiftId;
+                if (sourceShiftId === targetShiftId) return;
+
+                const targetShift = schedule[targetDayIndex]?.find(s => s.id === targetShiftId);
+                const sourceEmployee = state.employees.find(e => e.id === sourceShift.employeeId);
+                if (!targetShift || !targetShift.employeeId || !sourceEmployee) return;
+
+                const validationForTarget = this.validateShiftForEmployee(targetEmployee, sourceShift, targetDayIndex, weekId, [targetShift.id]);
+                if (!validationForTarget.pass) {
+                    showToast(validationForTarget.message, "error");
                     return;
                 }
 
-                const targetEmployee = store.getState().employees.find(e => e.id === targetEmployeeId);
-                if (!targetEmployee) return;
-
-                // Scenario 2: Swap
-                if (targetShiftElement) {
-                    const targetShiftId = targetShiftElement.dataset.shiftId;
-                    if (sourceShiftId === targetShiftId) return;
-
-                    const targetShift = schedule[targetDayIndex]?.find(s => s.id === targetShiftId);
-                    if (!targetShift || !targetShift.employeeId) return;
-
-                    // Swap logic (simplified check)
-                    [targetShift.employeeId, sourceShift.employeeId] = [sourceShift.employeeId, targetShift.employeeId];
+                const validationForSource = this.validateShiftForEmployee(sourceEmployee, targetShift, sourceDayIndex, weekId, [sourceShift.id]);
+                if (!validationForSource.pass) {
+                    showToast(validationForSource.message, "error");
+                    return;
                 }
-                // Scenario 3: Move/Assign
-                else {
-                    const sourceEmployeeId = sourceShift.employeeId;
-                    if (sourceEmployeeId === targetEmployeeId && sourceDayIndex === targetDayIndex) return;
 
-                    // Move logic
-                    // If moving day, need to splice and push.
-                    if (sourceDayIndex !== targetDayIndex) {
-                        const originalDayShifts = schedule[sourceDayIndex];
-                        const shiftIndex = originalDayShifts.findIndex(s => s.id === sourceShift.id);
-                        if (shiftIndex > -1) {
-                            const [shiftToMove] = originalDayShifts.splice(shiftIndex, 1);
-                            shiftToMove.employeeId = targetEmployee.id;
-                            this.ensureDay(targetDayIndex);
-                            schedule[targetDayIndex].push(shiftToMove);
-                        }
-                    } else {
-                        // Same day, just reassign
-                        sourceShift.employeeId = targetEmployee.id;
+                this.commitChange(() => {
+                    [targetShift.employeeId, sourceShift.employeeId] = [sourceShift.employeeId, targetShift.employeeId];
+                });
+                return;
+            }
+
+            // Scenario 3: Move/Assign
+            const sourceEmployeeId = sourceShift.employeeId;
+            if (sourceEmployeeId === targetEmployeeId && sourceDayIndex === targetDayIndex) return;
+
+            const validation = this.validateShiftForEmployee(targetEmployee, sourceShift, targetDayIndex, weekId, [sourceShift.id]);
+            if (!validation.pass) {
+                showToast(validation.message, "error");
+                return;
+            }
+
+            this.commitChange(() => {
+                if (sourceDayIndex !== targetDayIndex) {
+                    const originalDayShifts = schedule[sourceDayIndex];
+                    const shiftIndex = originalDayShifts.findIndex(s => s.id === sourceShift.id);
+                    if (shiftIndex > -1) {
+                        const [shiftToMove] = originalDayShifts.splice(shiftIndex, 1);
+                        shiftToMove.employeeId = targetEmployee.id;
+                        this.ensureDay(targetDayIndex);
+                        schedule[targetDayIndex].push(shiftToMove);
                     }
+                } else {
+                    sourceShift.employeeId = targetEmployee.id;
                 }
             });
         });

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -661,6 +661,32 @@ export const ScheduleManager = {
         schedule[d] = schedule[d] || [];
     },
 
+    ensureSavingIndicator() {
+        const container = el("#week-selector-container");
+        if (!container) return;
+
+        let badge = el("#schedule-saving-indicator");
+        if (!badge) {
+            badge = create("span", { id: "schedule-saving-indicator", className: "saving-indicator", textContent: "Sincronizado" });
+            container.appendChild(badge);
+        }
+    },
+
+    setSavingStatus(isSaving, hasError = false) {
+        const badge = el("#schedule-saving-indicator");
+        if (!badge) return;
+
+        badge.classList.toggle("active", isSaving);
+        badge.classList.toggle("error", !!hasError);
+        if (hasError) {
+            badge.textContent = "Error al guardar";
+        } else if (isSaving) {
+            badge.textContent = "Guardando…";
+        } else {
+            badge.textContent = "Sincronizado";
+        }
+    },
+
     validateShiftForEmployee(employee, shift, dayIndex, weekId, shiftsToIgnore = []) {
         if (!employee) return { pass: false, message: "Empleado no encontrado." };
         if (!shift && shift !== 0) return { pass: false, message: "Turno no válido." };
@@ -692,7 +718,7 @@ export const ScheduleManager = {
         return { pass: true, message: "" };
     },
 
-    async commitChange(action) {
+    commitChange(action) {
         const currentSchedule = getActiveSchedule();
         historyManager.push(currentSchedule);
         action();
@@ -700,12 +726,15 @@ export const ScheduleManager = {
         const btnUndo = el("#btnUndo");
         if(btnUndo) btnUndo.disabled = !historyManager.canUndo();
 
-        try {
-            await DataManager.saveState();
-        } catch (err) {
-            console.error("Error al guardar cambios de horario:", err);
-        }
         this.render();
+
+        this.setSavingStatus(true);
+        DataManager.saveState()
+            .then(() => this.setSavingStatus(false))
+            .catch((err) => {
+                console.error("Error al guardar cambios de horario:", err);
+                this.setSavingStatus(false, true);
+            });
     },
 
     undoLastAction() {
@@ -1226,6 +1255,9 @@ export const ScheduleManager = {
 
         const format = (d) => `${d.getDate()}/${d.getMonth()+1}`;
         btn.textContent = `${format(monday)} - ${format(sunday)}`;
+
+        this.ensureSavingIndicator();
+        this.setSavingStatus(false);
     },
 
     renderWeeklyStats() {

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -692,7 +692,7 @@ export const ScheduleManager = {
         return { pass: true, message: "" };
     },
 
-    commitChange(action) {
+    async commitChange(action) {
         const currentSchedule = getActiveSchedule();
         historyManager.push(currentSchedule);
         action();
@@ -700,7 +700,11 @@ export const ScheduleManager = {
         const btnUndo = el("#btnUndo");
         if(btnUndo) btnUndo.disabled = !historyManager.canUndo();
 
-        DataManager.saveState();
+        try {
+            await DataManager.saveState();
+        } catch (err) {
+            console.error("Error al guardar cambios de horario:", err);
+        }
         this.render();
     },
 

--- a/src/modules/UIManager.js
+++ b/src/modules/UIManager.js
@@ -11,11 +11,11 @@ export const UIManager = {
         const views = [
             { id: 'schedule', btn: '#btn-view-schedule' },
             { id: 'employees', btn: '#btn-view-employees' },
-            { id: 'templates', btn: '#btn-view-templates' },
-            { id: 'francos', btn: '#btn-view-francos' },
             { id: 'schedule-list', btn: '#btn-schedule-list' },
             { id: 'clock-ins', btn: '#btn-view-clock-ins' },
             { id: 'requests', btn: '#btn-view-requests' },
+            { id: 'templates', btn: '#btn-view-templates' },
+            { id: 'francos', btn: '#btn-view-francos' },
             { id: 'planilla-turno', btn: '#btn-planilla-turno' },
             { id: 'options', btn: '#btn-view-options' }
         ];
@@ -30,6 +30,7 @@ export const UIManager = {
         el("#btn-dark-mode")?.addEventListener("click", () => this.toggleDarkMode());
 
         this.bindActionsDropdown();
+        this.bindMoreDropdown();
 
         // Init Dark Mode
         if (localStorage.getItem("darkMode") === "enabled") {
@@ -38,8 +39,16 @@ export const UIManager = {
     },
 
     bindActionsDropdown() {
-        const btn = el('#btn-actions');
-        const dropdown = el('#actions-dropdown');
+        this.setupDropdown('#btn-actions', '#actions-dropdown');
+    },
+
+    bindMoreDropdown() {
+        this.setupDropdown('#btn-more', '#more-dropdown');
+    },
+
+    setupDropdown(btnSelector, dropdownSelector) {
+        const btn = el(btnSelector);
+        const dropdown = el(dropdownSelector);
         if (!btn || !dropdown) return;
 
         const hide = () => dropdown.classList.remove('show');
@@ -77,7 +86,6 @@ export const UIManager = {
         // Reset buttons
         document.querySelectorAll('.main-menu-btn').forEach(btn => {
             btn.classList.add('secondary');
-            // btn.classList.remove('main-menu-btn'); // Wait, they all keep the class, just toggle secondary
         });
 
         // Show specific view

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -58,17 +58,11 @@ function showSessionBanner(onChangeStore, onLogout) {
       <div class="row" style="gap:8px; align-items:center;">
         <span class="pill" id="session-user-label"></span>
         <span class="pill pill-neutral" id="session-store-label"></span>
-        <button id="change-store-btn" class="btn secondary">Cambiar local</button>
-        <button id="logout-btn" class="btn secondary">Salir</button>
       </div>
     `;
     const bar = document.querySelector('.bar-inner');
     if (bar) bar.appendChild(banner); else document.body.prepend(banner);
   }
-  const changeBtn = banner.querySelector('#change-store-btn');
-  changeBtn.onclick = onChangeStore;
-  const logoutBtn = banner.querySelector('#logout-btn');
-  logoutBtn.onclick = onLogout;
   banner.style.display = 'block';
 
   // Inline buttons in Acciones dropdown

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -70,6 +70,12 @@ function showSessionBanner(onChangeStore, onLogout) {
   const logoutBtn = banner.querySelector('#logout-btn');
   logoutBtn.onclick = onLogout;
   banner.style.display = 'block';
+
+  // Inline buttons in Acciones dropdown
+  const changeInline = document.getElementById('change-store-inline');
+  const logoutInline = document.getElementById('logout-inline');
+  if (changeInline) changeInline.onclick = onChangeStore;
+  if (logoutInline) logoutInline.onclick = onLogout;
 }
 
 function updateBannerLabels() {

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -55,13 +55,11 @@ function showSessionBanner(onChangeStore, onLogout) {
     banner.id = 'session-banner';
     banner.className = 'session-banner';
     banner.innerHTML = `
-      <div class="row" style="gap:8px; align-items:center;">
         <span class="pill" id="session-user-label"></span>
         <span class="pill pill-neutral" id="session-store-label"></span>
-      </div>
     `;
-    const bar = document.querySelector('.bar-inner');
-    if (bar) bar.appendChild(banner); else document.body.prepend(banner);
+    const container = document.querySelector('.main-bar-right') || document.querySelector('.bar-inner') || document.body;
+    container.prepend(banner);
   }
   banner.style.display = 'block';
 

--- a/style.css
+++ b/style.css
@@ -50,6 +50,9 @@
 .actions-dropdown{margin-left:0;}
 .more-dropdown{margin-left:8px;}
 .week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 16px;}
+.header-center{position:absolute; left:50%; transform:translateX(-50%); display:flex; flex-direction:column; align-items:center; gap:4px; pointer-events:none;}
+.header-center > * { pointer-events:auto; }
+.day-title{font-weight:600; font-size:14px; color: var(--ink);}
   h1{margin:0;font-size:18px}
 .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
 .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}

--- a/style.css
+++ b/style.css
@@ -41,11 +41,15 @@
     overflow: auto;
   }
   .wrap{max-width:1200px;margin:0 auto;padding:16px}
-  .bar{position:sticky;top:0;background:#ffffffcc;backdrop-filter:saturate(1.1) blur(6px);border-bottom:1px solid var(--border);z-index:50}
-  .bar-inner{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:12px 24px;}
+.bar{position:sticky;top:0;background:#ffffffcc;backdrop-filter:saturate(1.1) blur(6px);border-bottom:1px solid var(--border);z-index:50}
+.bar-inner{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:wrap;}
+.main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:wrap;}
+.main-menu{display:flex;flex-wrap:wrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
+.actions-dropdown{margin-left:auto;}
+.week-selector{gap:6px;}
   h1{margin:0;font-size:18px}
-  .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer}
-  .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}
+.btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
+.btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}
   .btn.danger{background:#ef4444;border-color:#ef4444;color:#fff;}
   .btn:disabled{opacity:.6;cursor:not-allowed}
   .select,.input,.file{

--- a/style.css
+++ b/style.css
@@ -46,7 +46,8 @@
 .main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:wrap;}
 .main-menu{display:flex;flex-wrap:wrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
 .actions-dropdown{margin-left:auto;}
-.week-selector{gap:6px;}
+.more-dropdown{margin-left:auto;}
+.week-selector{gap:6px; justify-content:center; flex: 0 0 auto;}
   h1{margin:0;font-size:18px}
 .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
 .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}

--- a/style.css
+++ b/style.css
@@ -42,14 +42,14 @@
   }
   .wrap{max-width:1200px;margin:0 auto;padding:16px}
 .bar{position:sticky;top:0;background:#ffffffcc;backdrop-filter:saturate(1.1) blur(6px);border-bottom:1px solid var(--border);z-index:50}
-.bar-inner{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:wrap;}
-.main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:wrap;}
-.main-menu{display:flex;flex-wrap:wrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
-.main-bar-left{flex:1; display:flex; align-items:center; min-width: 320px;}
-.main-bar-right{flex:1; display:flex; align-items:center; gap:10px; justify-content:flex-end; min-width: 240px;}
+.bar-inner{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:nowrap;overflow-x:auto;}
+.main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:nowrap;}
+.main-menu{display:flex;flex-wrap:nowrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
+.main-bar-left{flex:1; display:flex; align-items:center; min-width:0;}
+.main-bar-right{display:flex; align-items:center; gap:10px; flex:0 0 auto;}
 .actions-dropdown{margin-left:0;}
 .more-dropdown{margin-left:8px;}
-.week-selector{gap:6px; justify-content:center; flex: 1 1 260px; margin: 0 auto;}
+.week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 16px;}
   h1{margin:0;font-size:18px}
 .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
 .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}

--- a/style.css
+++ b/style.css
@@ -45,9 +45,11 @@
 .bar-inner{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:wrap;}
 .main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:wrap;}
 .main-menu{display:flex;flex-wrap:wrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
-.actions-dropdown{margin-left:auto;}
-.more-dropdown{margin-left:auto;}
-.week-selector{gap:6px; justify-content:center; flex: 0 0 auto;}
+.main-bar-left{flex:1; display:flex; align-items:center;}
+.main-bar-right{display:flex; align-items:center; gap:10px;}
+.actions-dropdown{margin-left:0;}
+.more-dropdown{margin-left:8px;}
+.week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 auto;}
   h1{margin:0;font-size:18px}
 .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
 .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}

--- a/style.css
+++ b/style.css
@@ -456,6 +456,11 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   overflow: visible;
 }
 
+/* Allow dropdowns and overflows (como exportar) without recortar contenido */
+.control-card {
+  overflow: visible;
+}
+
 /* width balancing handled via grid auto-fit */
 
 .control-card-head {
@@ -471,6 +476,15 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
 
 .employee-form-row {
   gap: 8px;
+  flex-wrap: wrap;
+}
+
+.employee-form-row .input {
+  flex: 1 1 200px;
+}
+
+.employee-form-row #btnAddEmp {
+  flex: 0 0 auto;
 }
 
 .filter-badges {

--- a/style.css
+++ b/style.css
@@ -759,6 +759,50 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   right: 0; /* Align to the right */
 }
 
+.saving-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 8px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--card);
+  border: 1px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.saving-indicator::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #22c55e;
+  display: inline-block;
+}
+
+.saving-indicator.active::before {
+  background: #f59e0b;
+  animation: saving-pulse 1s infinite ease-in-out;
+}
+
+.saving-indicator.error {
+  color: #b91c1c;
+  border-color: var(--c-danger);
+}
+
+.saving-indicator.error::before {
+  background: #b91c1c;
+  animation: none;
+}
+
+@keyframes saving-pulse {
+  0% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.25); opacity: 0.6; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
 .dropdown-content .dropdown-item {
   color: var(--ink);
   padding: 10px 14px;

--- a/style.css
+++ b/style.css
@@ -41,12 +41,12 @@
     overflow: auto;
   }
   .wrap{max-width:1200px;margin:0 auto;padding:16px}
-.bar{position:sticky;top:0;background:#ffffffcc;backdrop-filter:saturate(1.1) blur(6px);border-bottom:1px solid var(--border);z-index:50}
-.bar-inner{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:nowrap;overflow-x:auto;}
+.bar{position:sticky;top:0;background:#ffffffcc;backdrop-filter:saturate(1.1) blur(6px);border-bottom:1px solid var(--border);z-index:100;}
+.bar-inner{position:relative;display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:nowrap;overflow:visible;}
 .main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:nowrap;}
 .main-menu{display:flex;flex-wrap:nowrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
-.main-bar-left{flex:1; display:flex; align-items:center; min-width:0;}
-.main-bar-right{display:flex; align-items:center; gap:10px; flex:0 0 auto;}
+.main-bar-left{flex:1; display:flex; align-items:center; min-width:0; overflow:visible;}
+.main-bar-right{display:flex; align-items:center; gap:10px; flex:0 0 auto; overflow:visible;}
 .actions-dropdown{margin-left:0;}
 .more-dropdown{margin-left:8px;}
 .week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 16px;}
@@ -759,7 +759,7 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   background-color: var(--card);
   min-width: 160px;
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-  z-index: 51;
+  z-index: 2000;
   border: 1px solid var(--border);
   border-radius: 4px;
   overflow: hidden;

--- a/style.css
+++ b/style.css
@@ -45,11 +45,11 @@
 .bar-inner{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:wrap;}
 .main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:wrap;}
 .main-menu{display:flex;flex-wrap:wrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
-.main-bar-left{flex:1; display:flex; align-items:center;}
-.main-bar-right{display:flex; align-items:center; gap:10px;}
+.main-bar-left{flex:1; display:flex; align-items:center; min-width: 320px;}
+.main-bar-right{flex:1; display:flex; align-items:center; gap:10px; justify-content:flex-end; min-width: 240px;}
 .actions-dropdown{margin-left:0;}
 .more-dropdown{margin-left:8px;}
-.week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 auto;}
+.week-selector{gap:6px; justify-content:center; flex: 1 1 260px; margin: 0 auto;}
   h1{margin:0;font-size:18px}
 .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
 .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}

--- a/style.css
+++ b/style.css
@@ -50,9 +50,6 @@
 .actions-dropdown{margin-left:0;}
 .more-dropdown{margin-left:8px;}
 .week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 16px;}
-.header-center{position:absolute; left:50%; transform:translateX(-50%); display:flex; flex-direction:column; align-items:center; gap:4px; pointer-events:none;}
-.header-center > * { pointer-events:auto; }
-.day-title{font-weight:600; font-size:14px; color: var(--ink);}
   h1{margin:0;font-size:18px}
 .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
 .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}


### PR DESCRIPTION
## Summary
- show conflict warnings when disponibilidad o excepciones chocan con turnos asignados, permitiendo guardar tras confirmación
- enforce availability, rest, sanction, and overlap checks when moving or swapping shifts from the Listado view
- ajustar alta rápida de empleados y menús desplegables de reportes para que no se superpongan ni se recorten
- añadir campos de exportación para disponibilidad día a día y detalle de excepciones por empleado
- remover la opción de exportar “Disponibilidad (resumen)” dejando solo las vistas detalladas

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695046a61884832dac1440e5327b715e)