### PR TITLE
Ajusta header y controles en línea

### DIFF
--- a/manager.html
+++ b/manager.html
@@ -293,13 +293,13 @@
                 <div class="controls-center">
                     <div class="day-title-row">
                         <h2 id="day-title" class="day-title"></h2>
-                        <div id="weekly-stats-container" class="weekly-stats"></div>
                         <div class="day-metrics">
                             <label for="projectedTickets" class="muted mini-label">Tickets</label>
                             <input id="projectedTickets" type="number" class="input input-compact">
                             <span class="muted mini-label">Prod.</span>
                             <span id="projectedProductivity" class="strong"></span>
                         </div>
+                        <div id="weekly-stats-container" class="weekly-stats"></div>
                     </div>
                 </div>
                 <div class="controls-right">

--- a/manager.html
+++ b/manager.html
@@ -17,55 +17,53 @@
     <div class="loading-text">Cargando...</div>
   </div>
   <div class="bar">
-    <div class="bar-inner">
-                <button id="btn-view-requests" class="dropdown-item">Solicitudes</button>
-        <div id="week-selector-container" class="row week-selector">
-            <button id="btn-lock-week" class="btn secondary">🔓</button>
-            <button id="btn-prev-week" class="btn secondary">◄</button>
-            <button id="week-display" class="btn secondary"></button>
-            <button id="btn-next-week" class="btn secondary">►</button>
-              <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
-              <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
-              <button id="btn-weekly-summary" class="btn secondary main-menu-btn">Resumen semanal</button>
-              <div class="dropdown more-dropdown">
-                <button id="btn-more" class="btn secondary">Más ▾</button>
-                <div id="more-dropdown" class="dropdown-content">
-                  <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
-                  <button id="btn-view-francos" class="dropdown-item">Francos</button>
-                  <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
-                  <button id="btn-view-options" class="dropdown-item">Opciones</button>
-                </div>
-              </div>
-            </div>
-        </div>
-
-        <div id="week-selector-container" class="row week-selector">
-            <button id="btn-lock-week" class="btn secondary">🔓</button>
-            <button id="btn-prev-week" class="btn secondary">◄</button>
-            <button id="week-display" class="btn secondary"></button>
-            <button id="btn-next-week" class="btn secondary">►</button>
-        </div>
-
-        <div class="row main-bar-right">
-          <div id="session-banner" class="session-banner">
-            <span class="pill" id="session-user-label"></span>
-            <span class="pill pill-neutral" id="session-store-label"></span>
-          </div>
-          <div class="dropdown actions-dropdown">
-            <button id="btn-actions" class="btn secondary">Acciones ▾</button>
-            <div id="actions-dropdown" class="dropdown-content">
-              <button id="btnPrint" class="dropdown-item">Imprimir</button>
-              <button id="btn-import-text" class="dropdown-item">Importar desde texto</button>
-              <button id="btn-auto-assign" class="dropdown-item">Auto-completar Semana</button>
-              <div class="dropdown-divider"></div>
-              <button id="btn-advanced-import-export" class="dropdown-item">Importar/Exportar (Avanzado)</button>
-              <div class="dropdown-divider"></div>
-              <button id="change-store-inline" class="dropdown-item">Cambiar local</button>
-              <button id="logout-inline" class="dropdown-item">Salir</button>
+    <div class="bar-inner main-bar-row">
+      <div class="main-bar-left">
+        <div class="main-menu">
+          <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
+          <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
+          <button id="btn-schedule-list" class="btn secondary main-menu-btn">Listado</button>
+          <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
+          <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
+          <button id="btn-weekly-summary" class="btn secondary main-menu-btn">Resumen semanal</button>
+          <div class="dropdown more-dropdown">
+            <button id="btn-more" class="btn secondary">Más ▾</button>
+            <div id="more-dropdown" class="dropdown-content">
+              <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
+              <button id="btn-view-francos" class="dropdown-item">Francos</button>
+              <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
+              <button id="btn-view-options" class="dropdown-item">Opciones</button>
             </div>
           </div>
-          <button id="btn-dark-mode" class="btn secondary">🌙</button>
         </div>
+        <div class="dropdown actions-dropdown">
+          <button id="btn-actions" class="btn secondary">Acciones ▾</button>
+          <div id="actions-dropdown" class="dropdown-content">
+            <button id="btnPrint" class="dropdown-item">Imprimir</button>
+            <button id="btn-import-text" class="dropdown-item">Importar desde texto</button>
+            <button id="btn-auto-assign" class="dropdown-item">Auto-completar Semana</button>
+            <div class="dropdown-divider"></div>
+            <button id="btn-advanced-import-export" class="dropdown-item">Importar/Exportar (Avanzado)</button>
+            <div class="dropdown-divider"></div>
+            <button id="change-store-inline" class="dropdown-item">Cambiar local</button>
+            <button id="logout-inline" class="dropdown-item">Salir</button>
+          </div>
+        </div>
+      </div>
+
+      <div id="week-selector-container" class="row week-selector">
+        <button id="btn-lock-week" class="btn secondary">🔓</button>
+        <button id="btn-prev-week" class="btn secondary">◄</button>
+        <button id="week-display" class="btn secondary"></button>
+        <button id="btn-next-week" class="btn secondary">►</button>
+      </div>
+
+      <div class="row main-bar-right">
+        <div id="session-banner" class="session-banner">
+          <span class="pill" id="session-user-label"></span>
+          <span class="pill pill-neutral" id="session-store-label"></span>
+        </div>
+        <button id="btn-dark-mode" class="btn secondary">🌙</button>
       </div>
     </div>
   </div>
@@ -296,10 +294,12 @@
                     <div class="day-title-row">
                         <h2 id="day-title" class="day-title"></h2>
                         <div id="weekly-stats-container" class="weekly-stats"></div>
-                    </div>
-                    <div class="controls-group">
-                        <div class="control-item"><label for="projectedTickets" class="muted">Tickets</label><input id="projectedTickets" type="number" class="input"></div>
-                        <div class="control-item"><label class="muted">Prod.</label><span id="projectedProductivity" class="strong"></span></div>
+                        <div class="day-metrics">
+                            <label for="projectedTickets" class="muted mini-label">Tickets</label>
+                            <input id="projectedTickets" type="number" class="input input-compact">
+                            <span class="muted mini-label">Prod.</span>
+                            <span id="projectedProductivity" class="strong"></span>
+                        </div>
                     </div>
                 </div>
                 <div class="controls-right">

--- a/style.css
+++ b/style.css
@@ -934,6 +934,79 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   border-color: #7f1d1d;
 }
 
+/* Responsive: Mobile vertical layout */
+@media (max-width: 768px) {
+  .bar-inner.main-bar-row {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    align-items: flex-start;
+  }
+  .main-bar-left {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+  .main-menu {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 8px;
+  }
+  .main-menu .btn {
+    flex: 1 1 calc(50% - 8px);
+    min-width: 140px;
+  }
+  .actions-dropdown {
+    width: 100%;
+  }
+  .actions-dropdown .btn {
+    width: 100%;
+    text-align: left;
+  }
+  .week-selector {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: 0;
+  }
+  .main-bar-right {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .card-h-controls {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .controls-left,
+  .controls-center,
+  .controls-right {
+    grid-column: 1;
+    width: 100%;
+  }
+  .controls-group {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+  .controls-group .control-item {
+    flex: 1 1 140px;
+  }
+  .day-title-row {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .day-metrics,
+  .weekly-stats {
+    flex-wrap: wrap;
+  }
+  .weekly-stats {
+    gap: 6px;
+  }
+  .controls-right #dayTabs {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+}
+
 .controls-group {
   display: flex;
   align-items: center;

--- a/style.css
+++ b/style.css
@@ -43,13 +43,14 @@
   .wrap{max-width:1200px;margin:0 auto;padding:16px}
 .bar{position:sticky;top:0;background:#ffffffcc;backdrop-filter:saturate(1.1) blur(6px);border-bottom:1px solid var(--border);z-index:100;}
 .bar-inner{position:relative;display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:nowrap;overflow:visible;}
-.main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:nowrap;}
-.main-menu{display:flex;flex-wrap:nowrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
-.main-bar-left{flex:1; display:flex; align-items:center; min-width:0; overflow:visible;}
-.main-bar-right{display:flex; align-items:center; gap:10px; flex:0 0 auto; overflow:visible;}
+.bar-inner.main-bar-row{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:12px;}
+.main-bar-row{width:100%;align-items:center;}
+.main-menu{display:flex;flex-wrap:nowrap;gap:6px;flex:1;align-items:center;min-width:0;}
+.main-bar-left{display:flex; align-items:center; min-width:0; overflow:visible; gap:10px;}
+.main-bar-right{display:flex; align-items:center; gap:10px; justify-content:flex-end; min-width:0; overflow:visible;}
 .actions-dropdown{margin-left:0;}
 .more-dropdown{margin-left:8px;}
-.week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 16px;}
+.week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 auto;}
   h1{margin:0;font-size:18px}
 .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
 .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}
@@ -764,6 +765,7 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   border-radius: 4px;
   overflow: hidden;
   right: 0; /* Align to the right */
+  top: calc(100% + 6px);
 }
 
 .saving-indicator {
@@ -857,15 +859,36 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   font-weight: 600;
   margin: 0;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1 1 auto;
 }
 
 .day-title-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+  gap: 12px;
+  flex-wrap: nowrap;
   width: 100%;
-  justify-content: space-between;
+}
+
+.day-metrics {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+.day-metrics .input-compact {
+  width: 90px;
+}
+
+.weekly-stats {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted);
 }
 
 .assign-employee-list {
@@ -939,15 +962,6 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
 .mini-label {
   font-size: 11px;
   line-height: 1.2;
-}
-
-.weekly-stats {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  font-size: 12px;
-  color: var(--muted);
 }
 
 .weekly-stat-pill {


### PR DESCRIPTION
## Summary
- Reorganiza el header en una grilla 1-2-1 para centrar el selector de semana y agrupar menú, acciones y sesión en una sola línea
- Ajusta la posición de los dropdowns para que se desplieguen sobre el contenido sin desplazar elementos
- Coloca tickets y productividad junto al título del día con estilos compactos para mantener el encabezado de la grilla en una sola fila

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958cabc5c5c832db90899e31b8bfc9b)