### PR TITLE
Ajusta header y controles en línea

### DIFF
--- a/manager.html
+++ b/manager.html
@@ -17,55 +17,53 @@
     <div class="loading-text">Cargando...</div>
   </div>
   <div class="bar">
-    <div class="bar-inner">
-                <button id="btn-view-requests" class="dropdown-item">Solicitudes</button>
-        <div id="week-selector-container" class="row week-selector">
-            <button id="btn-lock-week" class="btn secondary">🔓</button>
-            <button id="btn-prev-week" class="btn secondary">◄</button>
-            <button id="week-display" class="btn secondary"></button>
-            <button id="btn-next-week" class="btn secondary">►</button>
-              <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
-              <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
-              <button id="btn-weekly-summary" class="btn secondary main-menu-btn">Resumen semanal</button>
-              <div class="dropdown more-dropdown">
-                <button id="btn-more" class="btn secondary">Más ▾</button>
-                <div id="more-dropdown" class="dropdown-content">
-                  <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
-                  <button id="btn-view-francos" class="dropdown-item">Francos</button>
-                  <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
-                  <button id="btn-view-options" class="dropdown-item">Opciones</button>
-                </div>
-              </div>
-            </div>
-        </div>
-
-        <div id="week-selector-container" class="row week-selector">
-            <button id="btn-lock-week" class="btn secondary">🔓</button>
-            <button id="btn-prev-week" class="btn secondary">◄</button>
-            <button id="week-display" class="btn secondary"></button>
-            <button id="btn-next-week" class="btn secondary">►</button>
-        </div>
-
-        <div class="row main-bar-right">
-          <div id="session-banner" class="session-banner">
-            <span class="pill" id="session-user-label"></span>
-            <span class="pill pill-neutral" id="session-store-label"></span>
-          </div>
-          <div class="dropdown actions-dropdown">
-            <button id="btn-actions" class="btn secondary">Acciones ▾</button>
-            <div id="actions-dropdown" class="dropdown-content">
-              <button id="btnPrint" class="dropdown-item">Imprimir</button>
-              <button id="btn-import-text" class="dropdown-item">Importar desde texto</button>
-              <button id="btn-auto-assign" class="dropdown-item">Auto-completar Semana</button>
-              <div class="dropdown-divider"></div>
-              <button id="btn-advanced-import-export" class="dropdown-item">Importar/Exportar (Avanzado)</button>
-              <div class="dropdown-divider"></div>
-              <button id="change-store-inline" class="dropdown-item">Cambiar local</button>
-              <button id="logout-inline" class="dropdown-item">Salir</button>
+    <div class="bar-inner main-bar-row">
+      <div class="main-bar-left">
+        <div class="main-menu">
+          <button id="btn-view-schedule" class="btn main-menu-btn">Horarios</button>
+          <button id="btn-view-employees" class="btn secondary main-menu-btn">Empleados</button>
+          <button id="btn-schedule-list" class="btn secondary main-menu-btn">Listado</button>
+          <button id="btn-view-clock-ins" class="btn secondary main-menu-btn">Fichadas</button>
+          <button id="btn-view-requests" class="btn secondary main-menu-btn">Solicitudes</button>
+          <button id="btn-weekly-summary" class="btn secondary main-menu-btn">Resumen semanal</button>
+          <div class="dropdown more-dropdown">
+            <button id="btn-more" class="btn secondary">Más ▾</button>
+            <div id="more-dropdown" class="dropdown-content">
+              <button id="btn-view-templates" class="dropdown-item">Plantillas</button>
+              <button id="btn-view-francos" class="dropdown-item">Francos</button>
+              <button id="btn-planilla-turno" class="dropdown-item">Planilla de Turno</button>
+              <button id="btn-view-options" class="dropdown-item">Opciones</button>
             </div>
           </div>
-          <button id="btn-dark-mode" class="btn secondary">🌙</button>
         </div>
+        <div class="dropdown actions-dropdown">
+          <button id="btn-actions" class="btn secondary">Acciones ▾</button>
+          <div id="actions-dropdown" class="dropdown-content">
+            <button id="btnPrint" class="dropdown-item">Imprimir</button>
+            <button id="btn-import-text" class="dropdown-item">Importar desde texto</button>
+            <button id="btn-auto-assign" class="dropdown-item">Auto-completar Semana</button>
+            <div class="dropdown-divider"></div>
+            <button id="btn-advanced-import-export" class="dropdown-item">Importar/Exportar (Avanzado)</button>
+            <div class="dropdown-divider"></div>
+            <button id="change-store-inline" class="dropdown-item">Cambiar local</button>
+            <button id="logout-inline" class="dropdown-item">Salir</button>
+          </div>
+        </div>
+      </div>
+
+      <div id="week-selector-container" class="row week-selector">
+        <button id="btn-lock-week" class="btn secondary">🔓</button>
+        <button id="btn-prev-week" class="btn secondary">◄</button>
+        <button id="week-display" class="btn secondary"></button>
+        <button id="btn-next-week" class="btn secondary">►</button>
+      </div>
+
+      <div class="row main-bar-right">
+        <div id="session-banner" class="session-banner">
+          <span class="pill" id="session-user-label"></span>
+          <span class="pill pill-neutral" id="session-store-label"></span>
+        </div>
+        <button id="btn-dark-mode" class="btn secondary">🌙</button>
       </div>
     </div>
   </div>
@@ -295,11 +293,13 @@
                 <div class="controls-center">
                     <div class="day-title-row">
                         <h2 id="day-title" class="day-title"></h2>
+                        <div class="day-metrics">
+                            <label for="projectedTickets" class="muted mini-label">Tickets</label>
+                            <input id="projectedTickets" type="number" class="input input-compact">
+                            <span class="muted mini-label">Prod.</span>
+                            <span id="projectedProductivity" class="strong"></span>
+                        </div>
                         <div id="weekly-stats-container" class="weekly-stats"></div>
-                    </div>
-                    <div class="controls-group">
-                        <div class="control-item"><label for="projectedTickets" class="muted">Tickets</label><input id="projectedTickets" type="number" class="input"></div>
-                        <div class="control-item"><label class="muted">Prod.</label><span id="projectedProductivity" class="strong"></span></div>
                     </div>
                 </div>
                 <div class="controls-right">

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -320,7 +320,7 @@ export const ScheduleManager = {
 
         if (!this.swapShiftSelectionId) {
             this.swapShiftSelectionId = shiftId;
-            showToast("Seleccioná otro turno asignado para completar el intercambio", "info");
+            showToast("Turno marcado. Elegí otro turno asignado para completar el intercambio", "info");
             this.renderTable();
             return;
         }
@@ -350,8 +350,7 @@ export const ScheduleManager = {
     },
 
     findShiftById(shiftId) {
-        const schedule = getActiveSchedule();
-        const days = this.getScheduleDays(schedule);
+        const days = this.getScheduleDaysArray();
         for (let dayIndex = 0; dayIndex < days.length; dayIndex++) {
             const found = days[dayIndex]?.find(s => s.id === shiftId);
             if (found) return found;
@@ -1220,8 +1219,8 @@ export const ScheduleManager = {
     },
 
     getEmployeeWeekShifts(employeeId) {
-        const schedule = getActiveSchedule();
-        const days = this.getScheduleDays(schedule);
+        const days = this.getScheduleDaysArray();
+        if (!days || typeof days.forEach !== "function") return [];
         const shifts = [];
         days.forEach((dayShifts, dayIndex) => {
             (dayShifts || []).forEach(s => {
@@ -1288,12 +1287,13 @@ export const ScheduleManager = {
         this.activeTooltipAnchor = null;
     },
 
-    getScheduleDays(schedule) {
-        if (Array.isArray(schedule)) return schedule;
-        const days = [];
-        for (let i = 0; i < 7; i++) {
-            days[i] = schedule && Array.isArray(schedule[i]) ? schedule[i] : (schedule?.[i] || []);
-        }
+    getScheduleDaysArray(scheduleOverride) {
+        const schedule = scheduleOverride ?? getActiveSchedule();
+        const days = Array.from({ length: 7 }, (_, i) => {
+            const direct = schedule?.[i];
+            if (Array.isArray(direct)) return direct;
+            return [];
+        });
         return days;
     },
 

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -16,6 +16,9 @@ import { EmployeeManager } from './EmployeeManager.js';
 import { showToast, showConfirmDialog, showAlertDialog } from '../utils/feedback.js';
 
 export const ScheduleManager = {
+    swapShiftSelectionId: null,
+    activeTooltipEl: null,
+    activeTooltipAnchor: null,
     init() {
         this.bindEvents();
     },
@@ -222,6 +225,7 @@ export const ScheduleManager = {
     },
 
     render() {
+        this.hideEmployeeWeekTooltip();
         const roles = this.getRoleList();
         const activeRoleSelect = el("#activeRole");
         const filterSelect = el("#schedule-role-filter");
@@ -305,6 +309,54 @@ export const ScheduleManager = {
             item.appendChild(actions);
             list.appendChild(item);
         });
+    },
+
+    handleSwapSelection(shiftId) {
+        const currentShift = this.findShiftById(shiftId);
+        if (!currentShift || !currentShift.employeeId) {
+            showToast("Seleccioná un turno asignado para intercambiar", "warning");
+            return;
+        }
+
+        if (!this.swapShiftSelectionId) {
+            this.swapShiftSelectionId = shiftId;
+            showToast("Seleccioná otro turno asignado para completar el intercambio", "info");
+            this.renderTable();
+            return;
+        }
+
+        if (this.swapShiftSelectionId === shiftId) {
+            this.swapShiftSelectionId = null;
+            this.renderTable();
+            return;
+        }
+
+        const otherShift = this.findShiftById(this.swapShiftSelectionId);
+        if (!otherShift || !otherShift.employeeId) {
+            this.swapShiftSelectionId = null;
+            showToast("El turno seleccionado ya no está asignado", "warning");
+            this.renderTable();
+            return;
+        }
+
+        this.commitChange(() => {
+            const tempEmp = currentShift.employeeId;
+            currentShift.employeeId = otherShift.employeeId;
+            otherShift.employeeId = tempEmp;
+        });
+        this.swapShiftSelectionId = null;
+        showToast("Turnos intercambiados", "success");
+        this.renderTable();
+    },
+
+    findShiftById(shiftId) {
+        const schedule = getActiveSchedule();
+        if (!schedule) return null;
+        for (let dayIndex = 0; dayIndex < schedule.length; dayIndex++) {
+            const found = schedule[dayIndex]?.find(s => s.id === shiftId);
+            if (found) return found;
+        }
+        return null;
     },
 
     async saveCurrentDayAsTemplate() {
@@ -499,6 +551,9 @@ export const ScheduleManager = {
                         }
                         const weeklyHours = this.getEmployeeWeeklyHours(emp.id);
                         empNameSpan.innerHTML = nameHtml + ` (${String(weeklyHours).replace('.', ',')}hs)`;
+                        empNameSpan.addEventListener("mouseenter", () => this.showEmployeeWeekTooltip(emp, empNameSpan));
+                        empNameSpan.addEventListener("mouseleave", () => this.hideEmployeeWeekTooltip());
+                        empNameSpan.addEventListener("mousemove", () => this.positionEmployeeWeekTooltip(empNameSpan));
                     } else {
                         empNameSpan.textContent = "Empleado no encontrado";
                     }
@@ -533,6 +588,11 @@ export const ScheduleManager = {
                 // Actions Div
                 const actionsDiv = create("div", { className: "row", style: { position: "absolute", top: "5px", right: "5px" } });
                 actionsDiv.appendChild(create("button", {
+                    className: "btn secondary swap-button", innerHTML: "⇄",
+                    style: { padding: "2px 6px", fontSize: "10px" }, title: "Intercambiar turno",
+                    onClick: (e) => { e.stopPropagation(); this.handleSwapSelection(shift.id); }
+                }));
+                actionsDiv.appendChild(create("button", {
                     className: "btn secondary", innerHTML: "&#9998;",
                     style: { padding: "2px 6px", fontSize: "10px" }, title: "Editar turno",
                     onClick: (e) => { e.stopPropagation(); this.openEditShiftModal(shift.id); }
@@ -549,6 +609,9 @@ export const ScheduleManager = {
                         if (confirmed) this.deleteShift(shift.id);
                     }
                 }));
+                if (this.swapShiftSelectionId === shift.id) {
+                    namecol.classList.add("swap-selected");
+                }
                 namecol.appendChild(actionsDiv);
                 row.appendChild(namecol);
 
@@ -1154,6 +1217,75 @@ export const ScheduleManager = {
         const formattedDate = `${dayName}, ${dayDate.getDate()} de ${dayDate.toLocaleString('es-ES', { month: 'long' })}`;
         const dayTitleEl = el("#day-title");
         if (dayTitleEl) dayTitleEl.textContent = formattedDate;
+    },
+
+    getEmployeeWeekShifts(employeeId) {
+        const schedule = getActiveSchedule();
+        if (!schedule) return [];
+        const shifts = [];
+        schedule.forEach((dayShifts, dayIndex) => {
+            (dayShifts || []).forEach(s => {
+                if (s.employeeId === employeeId) {
+                    shifts.push({
+                        dayIndex,
+                        role: s.role,
+                        startSlot: s.startSlot,
+                        endSlot: s.endSlot
+                    });
+                }
+            });
+        });
+        return shifts;
+    },
+
+    showEmployeeWeekTooltip(employee, anchor) {
+        if (!employee) return;
+        const shifts = this.getEmployeeWeekShifts(employee.id);
+
+        this.hideEmployeeWeekTooltip();
+        const tooltip = create("div", { className: "employee-week-tooltip card" });
+        const content = create("div", { className: "card-c stack", style: { gap: "4px" } });
+
+        if (!shifts.length) {
+            content.appendChild(create("div", { className: "muted mini-label", textContent: "Sin turnos en la semana" }));
+        } else {
+            const maxItems = 8;
+            shifts.slice(0, maxItems).forEach(s => {
+                const startLabel = SLOTS[s.startSlot]?.label || "";
+                const endLabel = SLOTS[s.endSlot + 1]?.label || SLOTS[s.endSlot]?.label || "";
+                const dayName = DAYS[s.dayIndex] || "";
+                content.appendChild(create("div", {
+                    className: "tooltip-row",
+                    textContent: `${dayName}: ${startLabel} - ${endLabel} · ${s.role}`
+                }));
+            });
+            if (shifts.length > maxItems) {
+                content.appendChild(create("div", { className: "muted mini-label", textContent: `+${shifts.length - maxItems} turnos más` }));
+            }
+        }
+
+        tooltip.appendChild(content);
+        document.body.appendChild(tooltip);
+        this.activeTooltipEl = tooltip;
+        this.activeTooltipAnchor = anchor;
+        this.positionEmployeeWeekTooltip(anchor);
+    },
+
+    positionEmployeeWeekTooltip(anchor) {
+        if (!this.activeTooltipEl || !anchor) return;
+        const rect = anchor.getBoundingClientRect();
+        this.activeTooltipEl.style.position = "absolute";
+        this.activeTooltipEl.style.zIndex = "2000";
+        this.activeTooltipEl.style.left = `${rect.left + window.scrollX}px`;
+        this.activeTooltipEl.style.top = `${rect.bottom + window.scrollY + 6}px`;
+    },
+
+    hideEmployeeWeekTooltip() {
+        if (this.activeTooltipEl?.parentNode) {
+            this.activeTooltipEl.parentNode.removeChild(this.activeTooltipEl);
+        }
+        this.activeTooltipEl = null;
+        this.activeTooltipAnchor = null;
     },
 
     updateScheduleFiltersUI() {

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -312,7 +312,8 @@ export const ScheduleManager = {
     },
 
     handleSwapSelection(shiftId) {
-        const currentShift = this.findShiftById(shiftId);
+        const currentShiftData = this.findShiftWithDay(shiftId);
+        const currentShift = currentShiftData?.shift;
         if (!currentShift || !currentShift.employeeId) {
             showToast("Seleccioná un turno asignado para intercambiar", "warning");
             return;
@@ -331,7 +332,8 @@ export const ScheduleManager = {
             return;
         }
 
-        const otherShift = this.findShiftById(this.swapShiftSelectionId);
+        const otherShiftData = this.findShiftWithDay(this.swapShiftSelectionId);
+        const otherShift = otherShiftData?.shift;
         if (!otherShift || !otherShift.employeeId) {
             this.swapShiftSelectionId = null;
             showToast("El turno seleccionado ya no está asignado", "warning");
@@ -339,21 +341,64 @@ export const ScheduleManager = {
             return;
         }
 
-        this.commitChange(() => {
-            const tempEmp = currentShift.employeeId;
-            currentShift.employeeId = otherShift.employeeId;
-            otherShift.employeeId = tempEmp;
-        });
-        this.swapShiftSelectionId = null;
-        showToast("Turnos intercambiados", "success");
-        this.renderTable();
+        const validationIssues = this.validateSwap(currentShiftData, otherShiftData);
+        const proceedSwap = () => {
+            this.commitChange(() => {
+                const tempEmp = currentShift.employeeId;
+                currentShift.employeeId = otherShift.employeeId;
+                otherShift.employeeId = tempEmp;
+            });
+            this.swapShiftSelectionId = null;
+            showToast("Turnos intercambiados", "success");
+            this.renderTable();
+        };
+
+        if (validationIssues.length) {
+            showConfirmDialog({
+                title: "Intercambio con advertencias",
+                message: validationIssues.join("<br>") + "<br><br>¿Aplicar el intercambio de todos modos?"
+            }).then(confirmed => {
+                if (confirmed) proceedSwap();
+                else this.renderTable();
+            });
+        } else {
+            proceedSwap();
+        }
+    },
+
+    validateSwap(currentShiftData, otherShiftData) {
+        const issues = [];
+        const state = store.getState();
+        const employeeA = state.employees.find(e => e.id === currentShiftData.shift.employeeId);
+        const employeeB = state.employees.find(e => e.id === otherShiftData.shift.employeeId);
+        const weekId = state.activeWeek;
+
+        const days = this.getScheduleDaysArray();
+        const shiftsDayA = (days[currentShiftData.dayIndex] || []).filter(s => s.id !== currentShiftData.shift.id && s.id !== otherShiftData.shift.id);
+        const shiftsDayB = (days[otherShiftData.dayIndex] || []).filter(s => s.id !== otherShiftData.shift.id && s.id !== currentShiftData.shift.id);
+
+        const tempShiftForB = { ...currentShiftData.shift };
+        const tempShiftForA = { ...otherShiftData.shift };
+
+        const checkB = this.validateShiftForEmployee(employeeB, tempShiftForB, currentShiftData.dayIndex, weekId, shiftsDayA);
+        if (!checkB.pass) issues.push(`Para ${employeeB?.name || "empleado"}: ${checkB.message}`);
+
+        const checkA = this.validateShiftForEmployee(employeeA, tempShiftForA, otherShiftData.dayIndex, weekId, shiftsDayB);
+        if (!checkA.pass) issues.push(`Para ${employeeA?.name || "empleado"}: ${checkA.message}`);
+
+        return issues;
     },
 
     findShiftById(shiftId) {
+        const result = this.findShiftWithDay(shiftId);
+        return result?.shift || null;
+    },
+
+    findShiftWithDay(shiftId) {
         const days = this.getScheduleDaysArray();
         for (let dayIndex = 0; dayIndex < days.length; dayIndex++) {
             const found = days[dayIndex]?.find(s => s.id === shiftId);
-            if (found) return found;
+            if (found) return { shift: found, dayIndex };
         }
         return null;
     },

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -351,9 +351,9 @@ export const ScheduleManager = {
 
     findShiftById(shiftId) {
         const schedule = getActiveSchedule();
-        if (!schedule) return null;
-        for (let dayIndex = 0; dayIndex < schedule.length; dayIndex++) {
-            const found = schedule[dayIndex]?.find(s => s.id === shiftId);
+        const days = this.getScheduleDays(schedule);
+        for (let dayIndex = 0; dayIndex < days.length; dayIndex++) {
+            const found = days[dayIndex]?.find(s => s.id === shiftId);
             if (found) return found;
         }
         return null;
@@ -1221,9 +1221,9 @@ export const ScheduleManager = {
 
     getEmployeeWeekShifts(employeeId) {
         const schedule = getActiveSchedule();
-        if (!schedule) return [];
+        const days = this.getScheduleDays(schedule);
         const shifts = [];
-        schedule.forEach((dayShifts, dayIndex) => {
+        days.forEach((dayShifts, dayIndex) => {
             (dayShifts || []).forEach(s => {
                 if (s.employeeId === employeeId) {
                     shifts.push({
@@ -1286,6 +1286,15 @@ export const ScheduleManager = {
         }
         this.activeTooltipEl = null;
         this.activeTooltipAnchor = null;
+    },
+
+    getScheduleDays(schedule) {
+        if (Array.isArray(schedule)) return schedule;
+        const days = [];
+        for (let i = 0; i < 7; i++) {
+            days[i] = schedule && Array.isArray(schedule[i]) ? schedule[i] : (schedule?.[i] || []);
+        }
+        return days;
     },
 
     updateScheduleFiltersUI() {

--- a/style.css
+++ b/style.css
@@ -43,13 +43,14 @@
   .wrap{max-width:1200px;margin:0 auto;padding:16px}
 .bar{position:sticky;top:0;background:#ffffffcc;backdrop-filter:saturate(1.1) blur(6px);border-bottom:1px solid var(--border);z-index:100;}
 .bar-inner{position:relative;display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px 16px;flex-wrap:nowrap;overflow:visible;}
-.main-bar-row{width:100%;gap:10px;align-items:center;flex-wrap:nowrap;}
-.main-menu{display:flex;flex-wrap:nowrap;gap:8px;flex:1;align-items:center;min-width: 320px;}
-.main-bar-left{flex:1; display:flex; align-items:center; min-width:0; overflow:visible;}
-.main-bar-right{display:flex; align-items:center; gap:10px; flex:0 0 auto; overflow:visible;}
+.bar-inner.main-bar-row{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:12px;}
+.main-bar-row{width:100%;align-items:center;}
+.main-menu{display:flex;flex-wrap:nowrap;gap:6px;flex:1;align-items:center;min-width:0;}
+.main-bar-left{display:flex; align-items:center; min-width:0; overflow:visible; gap:10px;}
+.main-bar-right{display:flex; align-items:center; gap:10px; justify-content:flex-end; min-width:0; overflow:visible;}
 .actions-dropdown{margin-left:0;}
 .more-dropdown{margin-left:8px;}
-.week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 16px;}
+.week-selector{gap:6px; justify-content:center; flex: 0 0 auto; margin: 0 auto;}
   h1{margin:0;font-size:18px}
 .btn{border:1px solid var(--ink);background:var(--ink);color:#fff;border-radius:4px;padding:8px 12px;cursor:pointer;white-space:nowrap}
 .btn.secondary{background:#fff;color:var(--ink);border-color:var(--border)}
@@ -764,6 +765,7 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   border-radius: 4px;
   overflow: hidden;
   right: 0; /* Align to the right */
+  top: calc(100% + 6px);
 }
 
 .saving-indicator {
@@ -857,15 +859,56 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   font-weight: 600;
   margin: 0;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1 1 auto;
 }
 
 .day-title-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+  gap: 12px;
+  flex-wrap: nowrap;
   width: 100%;
-  justify-content: space-between;
+}
+
+.day-metrics {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+.day-metrics .input-compact {
+  width: 90px;
+}
+
+.weekly-stats {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.swap-button {
+  font-weight: 700;
+}
+
+.swap-selected {
+  outline: 2px solid var(--c-active-border);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.employee-week-tooltip {
+  min-width: 220px;
+  box-shadow: 0 8px 18px rgba(0,0,0,0.14);
+}
+
+.employee-week-tooltip .tooltip-row {
+  font-size: 12px;
+  line-height: 1.3;
 }
 
 .assign-employee-list {
@@ -911,6 +954,79 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
   border-color: #7f1d1d;
 }
 
+/* Responsive: Mobile vertical layout */
+@media (max-width: 768px) {
+  .bar-inner.main-bar-row {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    align-items: flex-start;
+  }
+  .main-bar-left {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+  .main-menu {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 8px;
+  }
+  .main-menu .btn {
+    flex: 1 1 calc(50% - 8px);
+    min-width: 140px;
+  }
+  .actions-dropdown {
+    width: 100%;
+  }
+  .actions-dropdown .btn {
+    width: 100%;
+    text-align: left;
+  }
+  .week-selector {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: 0;
+  }
+  .main-bar-right {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .card-h-controls {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .controls-left,
+  .controls-center,
+  .controls-right {
+    grid-column: 1;
+    width: 100%;
+  }
+  .controls-group {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+  .controls-group .control-item {
+    flex: 1 1 140px;
+  }
+  .day-title-row {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .day-metrics,
+  .weekly-stats {
+    flex-wrap: wrap;
+  }
+  .weekly-stats {
+    gap: 6px;
+  }
+  .controls-right #dayTabs {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+}
+
 .controls-group {
   display: flex;
   align-items: center;
@@ -939,15 +1055,6 @@ body.dark-mode .b-warning { background: rgba(251, 191, 36, 0.16); color: #fde68a
 .mini-label {
   font-size: 11px;
   line-height: 1.2;
-}
-
-.weekly-stats {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  font-size: 12px;
-  color: var(--muted);
 }
 
 .weekly-stat-pill {


### PR DESCRIPTION
## Summary
- Reorganiza el header en una grilla 1-2-1 para centrar el selector de semana y agrupar menú, acciones y sesión en una sola línea
- Ajusta la posición de los dropdowns para que se desplieguen sobre el contenido sin desplazar elementos
- Coloca tickets y productividad junto al título del día con estilos compactos para mantener el encabezado de la grilla en una sola fila
- Intercambia la ubicación de las métricas diarias y semanales para que el indicador diario quede junto al título y el resumen semanal al lado
- Mejora el layout vertical en móvil apilando el header y los controles sin alterar la versión de escritorio
- Agrega intercambio directo de turnos entre dos empleados desde el botón de acciones y muestra un tooltip semanal al pasar el mouse por el nombre

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958cabc5c5c832db90899e31b8bfc9b)