### PR TITLE
Ajustar validación de intercambio de turnos

### DIFF
--- a/manager.html
+++ b/manager.html
@@ -333,16 +333,12 @@
       <section class="card">
         <div class="card-h"><strong>Listado de Horarios</strong></div>
         <div class="card-c" id="schedule-list-filter-bar">
-            <div class="row" style="justify-content: flex-end; width: 100%; gap: 12px; flex-wrap: wrap;">
+            <div class="row" style="justify-content: flex-end; width: 100%; gap: 12px; flex-wrap: wrap; align-items: flex-end;">
                 <div class="stack" style="min-width: 220px; flex: 1;">
                     <label class="muted mini-label" for="schedule-list-search">Buscar por empleado</label>
                     <input id="schedule-list-search" class="input" placeholder="Nombre o apellido">
                 </div>
-                <div class="stack" style="min-width: 240px; flex: 1;">
-                    <label class="muted mini-label" for="schedule-list-employee-filter">Seleccionar múltiples empleados</label>
-                    <select id="schedule-list-employee-filter" class="select" multiple size="6" style="width:100%;"></select>
-                    <button id="schedule-list-clear-filter" class="btn secondary" style="margin-top:6px; width:max-content;">Limpiar selección</button>
-                </div>
+                <button id="schedule-list-multi-btn" class="btn secondary" style="white-space: nowrap;">Selección múltiple</button>
             </div>
         </div>
         <div id="schedule-list-content" class="card-c">
@@ -539,6 +535,24 @@
             <button id="btn-print-daily-planning" class="btn">Planificación diaria</button>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Schedule List Multi-Select Modal -->
+  <div id="schedule-list-multi-modal" class="modal-overlay" style="display:none; z-index: 1500;">
+    <div class="modal-content card" style="max-width: 520px;">
+      <div class="card-h" style="display:flex; align-items:center; justify-content:space-between;">
+        <strong>Seleccionar múltiples empleados</strong>
+        <button id="schedule-list-multi-close" class="btn secondary del" style="margin-left:auto;">&times;</button>
+      </div>
+      <div class="card-c stack" style="max-height: 420px; overflow: auto; gap: 8px;">
+        <p class="muted" style="margin:0;">Usá el nombre de planilla para comparar horarios.</p>
+        <div id="schedule-list-multi-container" class="stack" style="gap: 6px;"></div>
+      </div>
+      <div class="card-c" style="display:flex; justify-content: flex-end; gap: 8px;">
+        <button id="schedule-list-clear-filter" class="btn secondary">Limpiar selección</button>
+        <button id="schedule-list-multi-close-footer" class="btn">Cerrar</button>
       </div>
     </div>
   </div>

--- a/manager.html
+++ b/manager.html
@@ -548,6 +548,10 @@
       </div>
       <div class="card-c stack" style="max-height: 420px; overflow: auto; gap: 8px;">
         <p class="muted" style="margin:0;">Usá el nombre de planilla para comparar horarios.</p>
+        <div class="stack" style="gap: 4px;">
+          <label class="muted mini-label" for="schedule-list-multi-search">Buscar empleado</label>
+          <input id="schedule-list-multi-search" class="input" placeholder="Nombre de planilla o nombre completo">
+        </div>
         <div id="schedule-list-multi-container" class="stack" style="gap: 6px;"></div>
       </div>
       <div class="card-c" style="display:flex; justify-content: flex-end; gap: 8px;">

--- a/manager.html
+++ b/manager.html
@@ -298,7 +298,7 @@
                             <input id="projectedTickets" type="number" class="input input-compact">
                             <span class="muted mini-label">Prod.</span>
                             <span id="projectedProductivity" class="strong"></span>
-                            <button id="btn-suggest-productivity" class="btn secondary" style="margin-left:8px;">Sugerir turnos (6.4)</button>
+                            <button id="btn-suggest-productivity" class="btn secondary" style="margin-left:8px;">Sugerir turnos (6.5)</button>
                         </div>
                         <div id="weekly-stats-container" class="weekly-stats"></div>
                     </div>

--- a/manager.html
+++ b/manager.html
@@ -298,6 +298,7 @@
                             <input id="projectedTickets" type="number" class="input input-compact">
                             <span class="muted mini-label">Prod.</span>
                             <span id="projectedProductivity" class="strong"></span>
+                            <button id="btn-suggest-productivity" class="btn secondary" style="margin-left:8px;">Sugerir turnos (6.4)</button>
                         </div>
                         <div id="weekly-stats-container" class="weekly-stats"></div>
                     </div>

--- a/manager.html
+++ b/manager.html
@@ -333,8 +333,16 @@
       <section class="card">
         <div class="card-h"><strong>Listado de Horarios</strong></div>
         <div class="card-c" id="schedule-list-filter-bar">
-            <div class="row" style="justify-content: flex-end; width: 100%;">
-                <input id="schedule-list-search" class="input" placeholder="Buscar por empleado...">
+            <div class="row" style="justify-content: flex-end; width: 100%; gap: 12px; flex-wrap: wrap;">
+                <div class="stack" style="min-width: 220px; flex: 1;">
+                    <label class="muted mini-label" for="schedule-list-search">Buscar por empleado</label>
+                    <input id="schedule-list-search" class="input" placeholder="Nombre o apellido">
+                </div>
+                <div class="stack" style="min-width: 240px; flex: 1;">
+                    <label class="muted mini-label" for="schedule-list-employee-filter">Seleccionar múltiples empleados</label>
+                    <select id="schedule-list-employee-filter" class="select" multiple size="6" style="width:100%;"></select>
+                    <button id="schedule-list-clear-filter" class="btn secondary" style="margin-top:6px; width:max-content;">Limpiar selección</button>
+                </div>
             </div>
         </div>
         <div id="schedule-list-content" class="card-c">

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -122,15 +122,34 @@ export const ScheduleManager = {
             store.setState({ scheduleSearchTerm: e.target.value });
             this.renderScheduleList();
         });
-        el("#schedule-list-employee-filter")?.addEventListener("change", (e) => {
-            const selectedIds = Array.from(e.target.selectedOptions || []).map(opt => opt.value);
-            store.setState({ scheduleSelectedEmployeeIds: selectedIds });
-            this.renderScheduleList();
+        const openMultiModal = () => {
+            this.updateScheduleListFiltersUI();
+            const modal = el("#schedule-list-multi-modal");
+            if (modal) modal.style.display = "flex";
+        };
+        const closeMultiModal = () => {
+            const modal = el("#schedule-list-multi-modal");
+            if (modal) modal.style.display = "none";
+        };
+        el("#schedule-list-multi-btn")?.addEventListener("click", openMultiModal);
+        el("#schedule-list-multi-close")?.addEventListener("click", closeMultiModal);
+        el("#schedule-list-multi-close-footer")?.addEventListener("click", closeMultiModal);
+        el("#schedule-list-multi-modal")?.addEventListener("click", (e) => {
+            if (e.target === el("#schedule-list-multi-modal")) closeMultiModal();
         });
         el("#schedule-list-clear-filter")?.addEventListener("click", () => {
             store.setState({ scheduleSelectedEmployeeIds: [] });
-            const select = el("#schedule-list-employee-filter");
-            if (select) Array.from(select.options).forEach(o => o.selected = false);
+            this.updateScheduleListFiltersUI();
+            this.renderScheduleList();
+        });
+        el("#schedule-list-multi-container")?.addEventListener("change", (e) => {
+            const target = e.target;
+            if (!target || !target.classList?.contains("schedule-list-multi-checkbox")) return;
+            const empId = target.value;
+            const selectedSet = new Set((store.getState().scheduleSelectedEmployeeIds || []).map(String));
+            if (target.checked) selectedSet.add(empId);
+            else selectedSet.delete(empId);
+            store.setState({ scheduleSelectedEmployeeIds: Array.from(selectedSet) });
             this.renderScheduleList();
         });
 
@@ -1387,17 +1406,34 @@ export const ScheduleManager = {
             searchInput.value = state.scheduleSearchTerm || "";
         }
 
-        const select = el("#schedule-list-employee-filter");
-        if (!select) return;
+        const container = el("#schedule-list-multi-container");
+        if (!container) return;
 
         const selectedSet = new Set((state.scheduleSelectedEmployeeIds || []).map(String));
-        clear(select);
+        clear(container);
 
-        const employees = state.employees.slice().sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+        const employees = state.employees.slice().sort((a, b) => (a.displayName || a.name || '').localeCompare(b.displayName || b.name || ''));
         employees.forEach(emp => {
-            const opt = create("option", { value: String(emp.id), textContent: emp.name || '' });
-            opt.selected = selectedSet.has(String(emp.id));
-            select.appendChild(opt);
+            const checkbox = create("input", {
+                type: "checkbox",
+                className: "schedule-list-multi-checkbox",
+                value: String(emp.id),
+                checked: selectedSet.has(String(emp.id))
+            });
+            const label = create("label", {
+                className: "row",
+                style: { gap: "8px", alignItems: "center" }
+            });
+            label.appendChild(checkbox);
+
+            const textStack = create("div", { className: "stack", style: { gap: "2px" } });
+            textStack.appendChild(create("div", { textContent: emp.displayName || emp.name || "" }));
+            if (emp.displayName && emp.name && emp.displayName !== emp.name) {
+                textStack.appendChild(create("div", { className: "muted", style: { fontSize: "12px" }, textContent: emp.name }));
+            }
+
+            label.appendChild(textStack);
+            container.appendChild(label);
         });
     },
 

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1412,47 +1412,7 @@ export const ScheduleManager = {
             return;
         }
 
-        const requiredHours = projectedTickets / targetProductivity;
-        if (!Number.isFinite(requiredHours) || requiredHours <= 0) {
-            showToast("No se pudo calcular las horas necesarias.", "warning");
-            return;
-        }
-
-        // Recolectar histórico de roles/slots del mismo día en semanas previas
-        const roleHours = {};
-        const roleStartCount = {};
-        const roleShiftLengths = {};
-        const globalStartCount = {};
         const dayIndex = state.activeDay;
-        const schedules = state.schedules || {};
-        Object.entries(schedules).forEach(([weekKey, weekData]) => {
-            if (weekKey === state.activeWeek || !weekData) return;
-            const dayShifts = weekData[dayIndex] || [];
-            dayShifts.forEach(shift => {
-                if (shift.startSlot === undefined || shift.endSlot === undefined) return;
-                const hours = (shift.endSlot - shift.startSlot + 1) / 2;
-                if (hours > 0) {
-                    roleHours[shift.role] = (roleHours[shift.role] || 0) + hours;
-                    roleShiftLengths[shift.role] = roleShiftLengths[shift.role] || [];
-                    roleShiftLengths[shift.role].push(hours);
-                }
-                roleStartCount[shift.role] = roleStartCount[shift.role] || {};
-                roleStartCount[shift.role][shift.startSlot] = (roleStartCount[shift.role][shift.startSlot] || 0) + 1;
-                globalStartCount[shift.startSlot] = (globalStartCount[shift.startSlot] || 0) + 1;
-            });
-        });
-
-        const totalRoleHours = Object.values(roleHours).reduce((a, b) => a + b, 0);
-        const availableRoles = state.roles?.length ? state.roles.map(r => r.key) : ROLES.map(r => r.key);
-        const roleWeights = {};
-        if (totalRoleHours > 0) {
-            availableRoles.forEach(r => {
-                roleWeights[r] = (roleHours[r] || 0) / totalRoleHours;
-            });
-        } else {
-            const even = availableRoles.length ? 1 / availableRoles.length : 0;
-            availableRoles.forEach(r => roleWeights[r] = even);
-        }
 
         const median = arr => {
             if (!arr || !arr.length) return null;
@@ -1461,75 +1421,151 @@ export const ScheduleManager = {
             return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
         };
 
-        const fallbackStart = (() => {
-            const sorted = Object.entries(globalStartCount).sort((a, b) => b[1] - a[1]);
-            if (sorted.length) return Number(sorted[0][0]);
-            return SLOTS.find(s => s.label === "09:00")?.index ?? 18;
-        })();
+        const generateForTarget = (targetProd) => {
+            const requiredHours = projectedTickets / targetProd;
+            if (!Number.isFinite(requiredHours) || requiredHours <= 0) return null;
 
-        const hoursPerRole = {};
-        availableRoles.forEach(r => {
-            hoursPerRole[r] = requiredHours * (roleWeights[r] || 0);
-        });
+            const roleHours = {};
+            const roleStartCount = {};
+            const roleShiftLengths = {};
+            const globalStartCount = {};
+            const schedules = state.schedules || {};
+            Object.entries(schedules).forEach(([weekKey, weekData]) => {
+                if (weekKey === state.activeWeek || !weekData) return;
+                const dayShifts = weekData[dayIndex] || [];
+                dayShifts.forEach(shift => {
+                    if (shift.startSlot === undefined || shift.endSlot === undefined) return;
+                    const hours = (shift.endSlot - shift.startSlot + 1) / 2;
+                    if (hours > 0) {
+                        roleHours[shift.role] = (roleHours[shift.role] || 0) + hours;
+                        roleShiftLengths[shift.role] = roleShiftLengths[shift.role] || [];
+                        roleShiftLengths[shift.role].push(hours);
+                    }
+                    roleStartCount[shift.role] = roleStartCount[shift.role] || {};
+                    roleStartCount[shift.role][shift.startSlot] = (roleStartCount[shift.role][shift.startSlot] || 0) + 1;
+                    globalStartCount[shift.startSlot] = (globalStartCount[shift.startSlot] || 0) + 1;
+                });
+            });
 
-        const schedule = getActiveSchedule();
-        this.ensureDay(dayIndex);
+            const totalRoleHours = Object.values(roleHours).reduce((a, b) => a + b, 0);
+            const availableRoles = state.roles?.length ? state.roles.map(r => r.key) : ROLES.map(r => r.key);
+            const roleWeights = {};
+            if (totalRoleHours > 0) {
+                availableRoles.forEach(r => {
+                    roleWeights[r] = (roleHours[r] || 0) / totalRoleHours;
+                });
+            } else {
+                const even = availableRoles.length ? 1 / availableRoles.length : 0;
+                availableRoles.forEach(r => roleWeights[r] = even);
+            }
 
-        const suggested = [];
-        let totalSuggestedHours = 0;
-        availableRoles.forEach(role => {
-            let remaining = hoursPerRole[role] || 0;
-            if (remaining <= 0) return;
+            const fallbackStart = (() => {
+                const sorted = Object.entries(globalStartCount).sort((a, b) => b[1] - a[1]);
+                if (sorted.length) return Number(sorted[0][0]);
+                return SLOTS.find(s => s.label === "09:00")?.index ?? 18;
+            })();
 
-            const roleMedian = median(roleShiftLengths[role] || []) || 6;
-            const shiftSlotLength = Math.max(1, Math.round(roleMedian * 2));
+            const hoursPerRole = {};
+            availableRoles.forEach(r => {
+                hoursPerRole[r] = requiredHours * (roleWeights[r] || 0);
+            });
 
-            const startSlots = Object.entries(roleStartCount[role] || {})
-                .sort((a, b) => b[1] - a[1])
-                .map(([slot]) => Number(slot));
+            const schedule = getActiveSchedule();
+            this.ensureDay(dayIndex);
 
-            let idx = 0;
-            while (remaining > 0 && totalSuggestedHours < requiredHours - 0.25) {
-                const startSlot = startSlots.length ? startSlots[idx % startSlots.length] : fallbackStart;
-                let endSlot = Math.min(SLOTS.length - 1, startSlot + shiftSlotLength - 1);
-                let hours = (endSlot - startSlot + 1) / 2;
+            const suggested = [];
+            let totalSuggestedHours = 0;
+            availableRoles.forEach(role => {
+                let remaining = hoursPerRole[role] || 0;
+                if (remaining <= 0) return;
 
-                const remainingGlobal = requiredHours - totalSuggestedHours;
-                if (hours > remainingGlobal && remainingGlobal > 0.5) {
-                    const allowedSlots = Math.max(1, Math.round(remainingGlobal * 2));
-                    endSlot = Math.min(SLOTS.length - 1, startSlot + allowedSlots - 1);
-                    hours = (endSlot - startSlot + 1) / 2;
-                } else if (hours > remainingGlobal && remainingGlobal <= 0.5) {
-                    break;
+                const roleMedian = median(roleShiftLengths[role] || []) || 6;
+                const shiftSlotLength = Math.max(1, Math.round(roleMedian * 2));
+
+                const startSlots = Object.entries(roleStartCount[role] || {})
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([slot]) => Number(slot));
+
+                // Seed shift en el horario más frecuente del rol para respetar patrones típicos del día (ej. descarga 06:00 martes/sábado)
+                if (startSlots.length && totalSuggestedHours < requiredHours - 0.25 && remaining > 0) {
+                    const startSlot = startSlots[0];
+                    const endSlot = Math.min(SLOTS.length - 1, startSlot + shiftSlotLength - 1);
+                    const hours = (endSlot - startSlot + 1) / 2;
+                    suggested.push({
+                        id: crypto.randomUUID(),
+                        role,
+                        startSlot,
+                        endSlot,
+                        employeeId: null
+                    });
+                    remaining -= hours;
+                    totalSuggestedHours += hours;
                 }
 
-                suggested.push({
-                    id: crypto.randomUUID(),
-                    role,
-                    startSlot,
-                    endSlot,
-                    employeeId: null
-                });
+                let idx = 0;
+                while (remaining > 0 && totalSuggestedHours < requiredHours - 0.25) {
+                    const startSlot = startSlots.length ? startSlots[idx % startSlots.length] : fallbackStart;
+                    let endSlot = Math.min(SLOTS.length - 1, startSlot + shiftSlotLength - 1);
+                    let hours = (endSlot - startSlot + 1) / 2;
 
-                remaining -= hours;
-                totalSuggestedHours += hours;
-                idx++;
+                    const remainingGlobal = requiredHours - totalSuggestedHours;
+                    if (hours > remainingGlobal && remainingGlobal > 0.5) {
+                        const allowedSlots = Math.max(1, Math.round(remainingGlobal * 2));
+                        endSlot = Math.min(SLOTS.length - 1, startSlot + allowedSlots - 1);
+                        hours = (endSlot - startSlot + 1) / 2;
+                    } else if (hours > remainingGlobal && remainingGlobal <= 0.5) {
+                        break;
+                    }
+
+                    suggested.push({
+                        id: crypto.randomUUID(),
+                        role,
+                        startSlot,
+                        endSlot,
+                        employeeId: null
+                    });
+
+                    remaining -= hours;
+                    totalSuggestedHours += hours;
+                    idx++;
+                }
+            });
+
+            if (!suggested.length) return null;
+            const estimatedProductivity = projectedTickets / totalSuggestedHours;
+            return { suggested, totalSuggestedHours, requiredHours, estimatedProductivity, targetProd };
+        };
+
+        const targets = [6.5, 6.4];
+        let result = null;
+        let usedTarget = null;
+        for (const target of targets) {
+            const attempt = generateForTarget(target);
+            if (attempt && attempt.estimatedProductivity >= target - 0.05) {
+                result = attempt;
+                usedTarget = target;
+                break;
             }
-        });
+            if (!result || (attempt && attempt.estimatedProductivity > result.estimatedProductivity)) {
+                result = attempt;
+                usedTarget = target;
+            }
+        }
 
-        if (!suggested.length) {
+        if (!result || !result.suggested?.length) {
             showToast("No se pudieron generar turnos sugeridos.", "warning");
             return;
         }
-        const estimatedProductivity = projectedTickets / totalSuggestedHours;
 
         showConfirmDialog({
             title: "Sugerencia de turnos",
-            message: `Tickets proyectados: ${projectedTickets}<br>Horas objetivo: ${requiredHours.toFixed(1)}hs<br>Horas sugeridas: ${totalSuggestedHours.toFixed(1)}hs<br>Prod. estimada: ${estimatedProductivity.toFixed(2)}<br><br>¿Agregar los turnos sugeridos al día?`
+            message: `Tickets proyectados: ${projectedTickets}<br>Meta de productividad: ${usedTarget.toFixed(1)}<br>Horas objetivo: ${(projectedTickets / usedTarget).toFixed(1)}hs<br>Horas sugeridas: ${result.totalSuggestedHours.toFixed(1)}hs<br>Prod. estimada: ${result.estimatedProductivity.toFixed(2)}<br><br>¿Agregar los turnos sugeridos al día?`
         }).then(confirmed => {
             if (!confirmed) return;
+            const schedule = getActiveSchedule();
+            this.ensureDay(state.activeDay);
             this.commitChange(() => {
-                schedule[dayIndex].push(...suggested);
+                schedule[state.activeDay].push(...result.suggested);
             });
             showToast("Turnos sugeridos agregados.", "success");
         });

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -373,17 +373,17 @@ export const ScheduleManager = {
         const employeeB = state.employees.find(e => e.id === otherShiftData.shift.employeeId);
         const weekId = state.activeWeek;
 
-        const days = this.getScheduleDaysArray();
-        const shiftsDayA = (days[currentShiftData.dayIndex] || []).filter(s => s.id !== currentShiftData.shift.id && s.id !== otherShiftData.shift.id);
-        const shiftsDayB = (days[otherShiftData.dayIndex] || []).filter(s => s.id !== otherShiftData.shift.id && s.id !== currentShiftData.shift.id);
+        const isSameDay = currentShiftData.dayIndex === otherShiftData.dayIndex;
+        const ignoreForEmployeeB = isSameDay ? [otherShiftData.shift.id] : [];
+        const ignoreForEmployeeA = isSameDay ? [currentShiftData.shift.id] : [];
 
         const tempShiftForB = { ...currentShiftData.shift };
         const tempShiftForA = { ...otherShiftData.shift };
 
-        const checkB = this.validateShiftForEmployee(employeeB, tempShiftForB, currentShiftData.dayIndex, weekId, shiftsDayA);
+        const checkB = this.validateShiftForEmployee(employeeB, tempShiftForB, currentShiftData.dayIndex, weekId, ignoreForEmployeeB);
         if (!checkB.pass) issues.push(`Para ${employeeB?.name || "empleado"}: ${checkB.message}`);
 
-        const checkA = this.validateShiftForEmployee(employeeA, tempShiftForA, otherShiftData.dayIndex, weekId, shiftsDayB);
+        const checkA = this.validateShiftForEmployee(employeeA, tempShiftForA, otherShiftData.dayIndex, weekId, ignoreForEmployeeA);
         if (!checkA.pass) issues.push(`Para ${employeeA?.name || "empleado"}: ${checkA.message}`);
 
         return issues;

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -122,6 +122,17 @@ export const ScheduleManager = {
             store.setState({ scheduleSearchTerm: e.target.value });
             this.renderScheduleList();
         });
+        el("#schedule-list-employee-filter")?.addEventListener("change", (e) => {
+            const selectedIds = Array.from(e.target.selectedOptions || []).map(opt => opt.value);
+            store.setState({ scheduleSelectedEmployeeIds: selectedIds });
+            this.renderScheduleList();
+        });
+        el("#schedule-list-clear-filter")?.addEventListener("click", () => {
+            store.setState({ scheduleSelectedEmployeeIds: [] });
+            const select = el("#schedule-list-employee-filter");
+            if (select) Array.from(select.options).forEach(o => o.selected = false);
+            this.renderScheduleList();
+        });
 
         // Calendar Modal
         el("#week-display")?.addEventListener("click", () => {
@@ -1350,6 +1361,7 @@ export const ScheduleManager = {
         const state = store.getState();
         const searchInput = el("#schedule-search");
         const roleSelect = el("#schedule-role-filter");
+        const scheduleListSearch = el("#schedule-list-search");
 
         if (searchInput && searchInput.value !== (state.scheduleSearchTerm || "")) {
             searchInput.value = state.scheduleSearchTerm || "";
@@ -1361,6 +1373,32 @@ export const ScheduleManager = {
                 opt.selected = selectedValues.has(opt.value);
             });
         }
+
+        if (scheduleListSearch && scheduleListSearch.value !== (state.scheduleSearchTerm || "")) {
+            scheduleListSearch.value = state.scheduleSearchTerm || "";
+        }
+    },
+
+    updateScheduleListFiltersUI() {
+        const state = store.getState();
+
+        const searchInput = el("#schedule-list-search");
+        if (searchInput && searchInput.value !== (state.scheduleSearchTerm || "")) {
+            searchInput.value = state.scheduleSearchTerm || "";
+        }
+
+        const select = el("#schedule-list-employee-filter");
+        if (!select) return;
+
+        const selectedSet = new Set((state.scheduleSelectedEmployeeIds || []).map(String));
+        clear(select);
+
+        const employees = state.employees.slice().sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+        employees.forEach(emp => {
+            const opt = create("option", { value: String(emp.id), textContent: emp.name || '' });
+            opt.selected = selectedSet.has(String(emp.id));
+            select.appendChild(opt);
+        });
     },
 
     renderLegend() {
@@ -1838,14 +1876,19 @@ export const ScheduleManager = {
         if(!content) return;
         clear(content);
 
+        this.updateScheduleListFiltersUI();
+
         const state = store.getState();
         const schedule = getActiveSchedule();
         if(!schedule) return;
 
         const searchTerm = (state.scheduleSearchTerm || '').toLowerCase().trim();
+        const selectedIds = new Set((state.scheduleSelectedEmployeeIds || []).map(String));
+
         const employees = state.employees
             .filter(emp => this.getEmployeeWeeklyHours(emp.id) > 0)
             .filter(emp => emp.name.toLowerCase().includes(searchTerm))
+            .filter(emp => selectedIds.size === 0 || selectedIds.has(String(emp.id)))
             .sort((a, b) => a.name.localeCompare(b.name));
 
         const unassignedShiftsExist = Object.values(schedule).some(day => Array.isArray(day) && day.some(s => !s.employeeId));

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -137,8 +137,13 @@ export const ScheduleManager = {
         el("#schedule-list-multi-modal")?.addEventListener("click", (e) => {
             if (e.target === el("#schedule-list-multi-modal")) closeMultiModal();
         });
+        el("#schedule-list-multi-search")?.addEventListener("input", (e) => {
+            store.setState({ scheduleSelectedEmployeeSearch: e.target.value });
+            this.updateScheduleListFiltersUI();
+        });
         el("#schedule-list-clear-filter")?.addEventListener("click", () => {
             store.setState({ scheduleSelectedEmployeeIds: [] });
+            store.setState({ scheduleSelectedEmployeeSearch: '' });
             this.updateScheduleListFiltersUI();
             this.renderScheduleList();
         });
@@ -1407,13 +1412,25 @@ export const ScheduleManager = {
         }
 
         const container = el("#schedule-list-multi-container");
+        const searchBox = el("#schedule-list-multi-search");
+        if (searchBox && searchBox.value !== (state.scheduleSelectedEmployeeSearch || "")) {
+            searchBox.value = state.scheduleSelectedEmployeeSearch || "";
+        }
         if (!container) return;
 
         const selectedSet = new Set((state.scheduleSelectedEmployeeIds || []).map(String));
+        const searchTerm = (state.scheduleSelectedEmployeeSearch || '').toLowerCase().trim();
         clear(container);
 
         const employees = state.employees.slice().sort((a, b) => (a.displayName || a.name || '').localeCompare(b.displayName || b.name || ''));
-        employees.forEach(emp => {
+        employees
+        .filter(emp => {
+            if (!searchTerm) return true;
+            const display = (emp.displayName || '').toLowerCase();
+            const full = (emp.name || '').toLowerCase();
+            return display.includes(searchTerm) || full.includes(searchTerm);
+        })
+        .forEach(emp => {
             const checkbox = create("input", {
                 type: "checkbox",
                 className: "schedule-list-multi-checkbox",
@@ -1470,8 +1487,13 @@ export const ScheduleManager = {
 
         const scheduleTbody = el('#view-schedule #tbody');
         if (scheduleTbody) {
-            scheduleTbody.style.pointerEvents = isLocked ? 'none' : 'auto';
-            scheduleTbody.style.opacity = isLocked ? 0.7 : 1;
+            scheduleTbody.style.pointerEvents = 'auto'; // permitir tooltip
+            scheduleTbody.style.opacity = 1;
+        }
+
+        const scheduleTable = document.querySelector('#view-schedule .table');
+        if (scheduleTable) {
+            scheduleTable.style.border = isLocked ? '2px solid var(--c-danger, #e53e3e)' : '';
         }
 
         const scheduleListContent = el('#schedule-list-content');

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -811,6 +811,10 @@ export const ScheduleManager = {
             return { pass: false, message: "El empleado es menor y no puede trabajar en este horario." };
         }
 
+        if (!shift.ignoreRestrictions && shift.role && !(employee.stars || []).includes(shift.role)) {
+            return { pass: false, message: `El empleado no tiene la estrella requerida para ${shift.role}.` };
+        }
+
         const overlapCheck = checkShiftOverlap(employee.id, shift, dayIndex, shiftsToIgnore);
         if (!overlapCheck.pass) return overlapCheck;
 

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -157,6 +157,7 @@ export const ScheduleManager = {
             store.setState({ scheduleSelectedEmployeeIds: Array.from(selectedSet) });
             this.renderScheduleList();
         });
+        el("#btn-suggest-productivity")?.addEventListener("click", () => this.suggestShiftsForProductivity());
 
         // Calendar Modal
         el("#week-display")?.addEventListener("click", () => {
@@ -1396,6 +1397,115 @@ export const ScheduleManager = {
     isWeekLocked() {
         const schedule = getActiveSchedule();
         return !!schedule?.isLocked;
+    },
+
+    suggestShiftsForProductivity(targetProductivity = 6.4) {
+        if (this.isWeekLocked()) {
+            showToast("La semana está bloqueada. Solo podés ver los turnos.", "warning");
+            return;
+        }
+
+        const state = store.getState();
+        const projectedTickets = Number((state.projectedTickets[state.activeWeek] || {})[state.activeDay] || 0);
+        if (!projectedTickets || projectedTickets <= 0) {
+            showToast("Ingresá tickets proyectados para el día.", "warning");
+            return;
+        }
+
+        const requiredHours = projectedTickets / targetProductivity;
+        if (!Number.isFinite(requiredHours) || requiredHours <= 0) {
+            showToast("No se pudo calcular las horas necesarias.", "warning");
+            return;
+        }
+
+        // Recolectar histórico de roles/slots del mismo día en semanas previas
+        const roleHours = {};
+        const startSlotCount = {};
+        const shiftLengths = [];
+        const dayIndex = state.activeDay;
+        const schedules = state.schedules || {};
+        Object.entries(schedules).forEach(([weekKey, weekData]) => {
+            if (weekKey === state.activeWeek || !weekData) return;
+            const dayShifts = weekData[dayIndex] || [];
+            dayShifts.forEach(shift => {
+                if (shift.startSlot === undefined || shift.endSlot === undefined) return;
+                const hours = (shift.endSlot - shift.startSlot + 1) / 2;
+                if (hours > 0) {
+                    roleHours[shift.role] = (roleHours[shift.role] || 0) + hours;
+                    shiftLengths.push(hours);
+                }
+                startSlotCount[shift.startSlot] = (startSlotCount[shift.startSlot] || 0) + 1;
+            });
+        });
+
+        const totalRoleHours = Object.values(roleHours).reduce((a, b) => a + b, 0);
+        const availableRoles = state.roles?.length ? state.roles.map(r => r.key) : ROLES.map(r => r.key);
+        const roleWeights = {};
+        if (totalRoleHours > 0) {
+            availableRoles.forEach(r => {
+                roleWeights[r] = (roleHours[r] || 0) / totalRoleHours;
+            });
+        } else {
+            const even = availableRoles.length ? 1 / availableRoles.length : 0;
+            availableRoles.forEach(r => roleWeights[r] = even);
+        }
+
+        const median = arr => {
+            if (!arr.length) return null;
+            const sorted = [...arr].sort((a, b) => a - b);
+            const mid = Math.floor(sorted.length / 2);
+            return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+        };
+        const defaultShiftHours = median(shiftLengths) || 6;
+        const shiftSlotLength = Math.max(1, Math.round(defaultShiftHours * 2));
+
+        const sortedStartSlots = Object.entries(startSlotCount)
+            .sort((a, b) => b[1] - a[1])
+            .map(([slot]) => Number(slot));
+        const fallbackStart = SLOTS.find(s => s.label === "09:00")?.index ?? 18;
+
+        const totalShifts = Math.max(1, Math.ceil(requiredHours / (shiftSlotLength / 2)));
+        const schedule = getActiveSchedule();
+        this.ensureDay(dayIndex);
+
+        const pickRole = (i) => {
+            const entries = Object.entries(roleWeights);
+            if (!entries.length) return availableRoles[0] || ROLES[0].key;
+            let acc = 0;
+            const mod = (i / totalShifts);
+            for (const [role, weight] of entries) {
+                acc += weight;
+                if (mod <= acc) return role;
+            }
+            return entries[entries.length - 1][0];
+        };
+
+        const suggested = [];
+        for (let i = 0; i < totalShifts; i++) {
+            const startSlot = sortedStartSlots[i % (sortedStartSlots.length || 1)] ?? fallbackStart;
+            const endSlot = Math.min(SLOTS.length - 1, startSlot + shiftSlotLength - 1);
+            suggested.push({
+                id: crypto.randomUUID(),
+                role: pickRole(i),
+                startSlot,
+                endSlot,
+                employeeId: null
+            });
+        }
+
+        const totalSuggestedHours = suggested.reduce((acc, s) => acc + ((s.endSlot - s.startSlot + 1) / 2), 0);
+        const estimatedProductivity = projectedTickets / totalSuggestedHours;
+
+        showConfirmDialog({
+            title: "Sugerencia de turnos",
+            message: `Tickets proyectados: ${projectedTickets}<br>Horas objetivo: ${requiredHours.toFixed(1)}hs<br>Horas sugeridas: ${totalSuggestedHours.toFixed(1)}hs<br>Prod. estimada: ${estimatedProductivity.toFixed(2)}<br><br>¿Agregar los turnos sugeridos al día?`
+        }).then(confirmed => {
+            if (!confirmed) return;
+            this.commitChange(() => {
+                schedule[dayIndex].push(...suggested);
+            });
+            showToast("Turnos sugeridos agregados.", "success");
+        });
     },
 
     updateScheduleFiltersUI() {

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1420,8 +1420,9 @@ export const ScheduleManager = {
 
         // Recolectar histórico de roles/slots del mismo día en semanas previas
         const roleHours = {};
-        const startSlotCount = {};
-        const shiftLengths = [];
+        const roleStartCount = {};
+        const roleShiftLengths = {};
+        const globalStartCount = {};
         const dayIndex = state.activeDay;
         const schedules = state.schedules || {};
         Object.entries(schedules).forEach(([weekKey, weekData]) => {
@@ -1432,9 +1433,12 @@ export const ScheduleManager = {
                 const hours = (shift.endSlot - shift.startSlot + 1) / 2;
                 if (hours > 0) {
                     roleHours[shift.role] = (roleHours[shift.role] || 0) + hours;
-                    shiftLengths.push(hours);
+                    roleShiftLengths[shift.role] = roleShiftLengths[shift.role] || [];
+                    roleShiftLengths[shift.role].push(hours);
                 }
-                startSlotCount[shift.startSlot] = (startSlotCount[shift.startSlot] || 0) + 1;
+                roleStartCount[shift.role] = roleStartCount[shift.role] || {};
+                roleStartCount[shift.role][shift.startSlot] = (roleStartCount[shift.role][shift.startSlot] || 0) + 1;
+                globalStartCount[shift.startSlot] = (globalStartCount[shift.startSlot] || 0) + 1;
             });
         });
 
@@ -1451,47 +1455,56 @@ export const ScheduleManager = {
         }
 
         const median = arr => {
-            if (!arr.length) return null;
+            if (!arr || !arr.length) return null;
             const sorted = [...arr].sort((a, b) => a - b);
             const mid = Math.floor(sorted.length / 2);
             return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
         };
-        const defaultShiftHours = median(shiftLengths) || 6;
-        const shiftSlotLength = Math.max(1, Math.round(defaultShiftHours * 2));
 
-        const sortedStartSlots = Object.entries(startSlotCount)
-            .sort((a, b) => b[1] - a[1])
-            .map(([slot]) => Number(slot));
-        const fallbackStart = SLOTS.find(s => s.label === "09:00")?.index ?? 18;
+        const fallbackStart = (() => {
+            const sorted = Object.entries(globalStartCount).sort((a, b) => b[1] - a[1]);
+            if (sorted.length) return Number(sorted[0][0]);
+            return SLOTS.find(s => s.label === "09:00")?.index ?? 18;
+        })();
 
-        const totalShifts = Math.max(1, Math.ceil(requiredHours / (shiftSlotLength / 2)));
+        const hoursPerRole = {};
+        availableRoles.forEach(r => {
+            hoursPerRole[r] = requiredHours * (roleWeights[r] || 0);
+        });
+
         const schedule = getActiveSchedule();
         this.ensureDay(dayIndex);
 
-        const pickRole = (i) => {
-            const entries = Object.entries(roleWeights);
-            if (!entries.length) return availableRoles[0] || ROLES[0].key;
-            let acc = 0;
-            const mod = (i / totalShifts);
-            for (const [role, weight] of entries) {
-                acc += weight;
-                if (mod <= acc) return role;
-            }
-            return entries[entries.length - 1][0];
-        };
-
         const suggested = [];
-        for (let i = 0; i < totalShifts; i++) {
-            const startSlot = sortedStartSlots[i % (sortedStartSlots.length || 1)] ?? fallbackStart;
-            const endSlot = Math.min(SLOTS.length - 1, startSlot + shiftSlotLength - 1);
-            suggested.push({
-                id: crypto.randomUUID(),
-                role: pickRole(i),
-                startSlot,
-                endSlot,
-                employeeId: null
-            });
-        }
+        availableRoles.forEach(role => {
+            let remaining = hoursPerRole[role] || 0;
+            if (remaining <= 0) return;
+
+            const roleMedian = median(roleShiftLengths[role] || []) || 6;
+            const shiftSlotLength = Math.max(1, Math.round(roleMedian * 2));
+
+            const startSlots = Object.entries(roleStartCount[role] || {})
+                .sort((a, b) => b[1] - a[1])
+                .map(([slot]) => Number(slot));
+
+            let idx = 0;
+            while (remaining > 0) {
+                const startSlot = startSlots.length ? startSlots[idx % startSlots.length] : fallbackStart;
+                const endSlot = Math.min(SLOTS.length - 1, startSlot + shiftSlotLength - 1);
+                const hours = (endSlot - startSlot + 1) / 2;
+
+                suggested.push({
+                    id: crypto.randomUUID(),
+                    role,
+                    startSlot,
+                    endSlot,
+                    employeeId: null
+                });
+
+                remaining -= hours;
+                idx++;
+            }
+        });
 
         const totalSuggestedHours = suggested.reduce((acc, s) => acc + ((s.endSlot - s.startSlot + 1) / 2), 0);
         const estimatedProductivity = projectedTickets / totalSuggestedHours;

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1399,7 +1399,7 @@ export const ScheduleManager = {
         return !!schedule?.isLocked;
     },
 
-    suggestShiftsForProductivity(targetProductivity = 6.4) {
+    suggestShiftsForProductivity(targetProductivity = 6.5) {
         if (this.isWeekLocked()) {
             showToast("La semana está bloqueada. Solo podés ver los turnos.", "warning");
             return;
@@ -1476,6 +1476,7 @@ export const ScheduleManager = {
         this.ensureDay(dayIndex);
 
         const suggested = [];
+        let totalSuggestedHours = 0;
         availableRoles.forEach(role => {
             let remaining = hoursPerRole[role] || 0;
             if (remaining <= 0) return;
@@ -1488,10 +1489,19 @@ export const ScheduleManager = {
                 .map(([slot]) => Number(slot));
 
             let idx = 0;
-            while (remaining > 0) {
+            while (remaining > 0 && totalSuggestedHours < requiredHours - 0.25) {
                 const startSlot = startSlots.length ? startSlots[idx % startSlots.length] : fallbackStart;
-                const endSlot = Math.min(SLOTS.length - 1, startSlot + shiftSlotLength - 1);
-                const hours = (endSlot - startSlot + 1) / 2;
+                let endSlot = Math.min(SLOTS.length - 1, startSlot + shiftSlotLength - 1);
+                let hours = (endSlot - startSlot + 1) / 2;
+
+                const remainingGlobal = requiredHours - totalSuggestedHours;
+                if (hours > remainingGlobal && remainingGlobal > 0.5) {
+                    const allowedSlots = Math.max(1, Math.round(remainingGlobal * 2));
+                    endSlot = Math.min(SLOTS.length - 1, startSlot + allowedSlots - 1);
+                    hours = (endSlot - startSlot + 1) / 2;
+                } else if (hours > remainingGlobal && remainingGlobal <= 0.5) {
+                    break;
+                }
 
                 suggested.push({
                     id: crypto.randomUUID(),
@@ -1502,11 +1512,15 @@ export const ScheduleManager = {
                 });
 
                 remaining -= hours;
+                totalSuggestedHours += hours;
                 idx++;
             }
         });
 
-        const totalSuggestedHours = suggested.reduce((acc, s) => acc + ((s.endSlot - s.startSlot + 1) / 2), 0);
+        if (!suggested.length) {
+            showToast("No se pudieron generar turnos sugeridos.", "warning");
+            return;
+        }
         const estimatedProductivity = projectedTickets / totalSuggestedHours;
 
         showConfirmDialog({

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -159,6 +159,8 @@ export const ScheduleManager = {
         });
         el("#btn-suggest-productivity")?.addEventListener("click", () => this.suggestShiftsForProductivity());
 
+        this.initSlotHoverHighlight();
+
         // Calendar Modal
         el("#week-display")?.addEventListener("click", () => {
             this.calendarDate = new Date(store.getState().activeWeek + "T12:00:00Z");
@@ -258,6 +260,38 @@ export const ScheduleManager = {
                 shiftDuration.textContent = "";
             }
         }
+    },
+
+    initSlotHoverHighlight() {
+        const table = el("#view-schedule .table");
+        if (!table || this.slotHoverBound) return;
+        this.slotHoverBound = true;
+        this.hoveredSlotIndex = null;
+        this.hoveredSlotEls = [];
+
+        const clearHover = () => {
+            if (this.hoveredSlotEls.length) {
+                this.hoveredSlotEls.forEach(el => el.classList.remove("hovered-slot-column"));
+            }
+            this.hoveredSlotEls = [];
+            this.hoveredSlotIndex = null;
+        };
+
+        table.addEventListener("mouseover", (e) => {
+            const cell = e.target.closest("[data-slot-index]");
+            if (!cell || !table.contains(cell)) return;
+            const slotIndex = cell.dataset.slotIndex;
+            if (slotIndex === this.hoveredSlotIndex) return;
+            clearHover();
+            const columnCells = table.querySelectorAll(`[data-slot-index="${slotIndex}"]`);
+            columnCells.forEach(el => el.classList.add("hovered-slot-column"));
+            this.hoveredSlotEls = Array.from(columnCells);
+            this.hoveredSlotIndex = slotIndex;
+        });
+
+        table.addEventListener("mouseleave", () => {
+            clearHover();
+        });
     },
 
     render() {
@@ -709,7 +743,7 @@ export const ScheduleManager = {
                 const isInConflict = emp && isDateInSanctionPeriod(shiftDate, emp.sanctions) && !shift.replacement;
 
                 for (let i = 0; i < SLOTS.length; i++) {
-                    const cell = create("div", { className: "slot", onClick: () => this.handleSlotClick(shift, i) });
+                    const cell = create("div", { className: "slot", dataset: { slotIndex: i }, onClick: () => this.handleSlotClick(shift, i) });
 
                     // Check availability for every slot
                     if (shift.employeeId && emp && isSlotUnavailable(emp, i, state.activeWeek, day)) {
@@ -773,6 +807,7 @@ export const ScheduleManager = {
         SLOTS.forEach((s, idx) => {
             const c = create("div", {
                 className: "slot-h",
+                dataset: { slotIndex: idx },
                 style: { display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: "1px", padding: "2px 0" }
             });
 

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -347,6 +347,10 @@ export const ScheduleManager = {
     },
 
     handleSwapSelection(shiftId) {
+        if (this.isWeekLocked()) {
+            showToast("La semana está bloqueada. Solo podés ver los turnos.", "warning");
+            return;
+        }
         const currentShiftData = this.findShiftWithDay(shiftId);
         const currentShift = currentShiftData?.shift;
         if (!currentShift || !currentShift.employeeId) {
@@ -865,6 +869,10 @@ export const ScheduleManager = {
     },
 
     commitChange(action) {
+        if (this.isWeekLocked()) {
+            showToast("La semana está bloqueada. Solo podés ver los turnos.", "warning");
+            return;
+        }
         const currentSchedule = getActiveSchedule();
         historyManager.push(currentSchedule);
         action();
@@ -914,6 +922,10 @@ export const ScheduleManager = {
     },
 
     addUnassignedShift() {
+        if (this.isWeekLocked()) {
+            showToast("La semana está bloqueada. Solo podés ver los turnos.", "warning");
+            return;
+        }
         const role = el("#activeRole").value;
         const startSlot = Number(el("#formStart").value);
         const endSlot = Number(el("#formEnd").value);
@@ -1379,6 +1391,11 @@ export const ScheduleManager = {
             return [];
         });
         return days;
+    },
+
+    isWeekLocked() {
+        const schedule = getActiveSchedule();
+        return !!schedule?.isLocked;
     },
 
     updateScheduleFiltersUI() {
@@ -1940,6 +1957,12 @@ export const ScheduleManager = {
         const schedule = getActiveSchedule();
         if(!schedule) return;
 
+        if (this.isWeekLocked()) {
+            content.classList.add("locked-view");
+        } else {
+            content.classList.remove("locked-view");
+        }
+
         const searchTerm = (state.scheduleSearchTerm || '').toLowerCase().trim();
         const selectedIds = new Set((state.scheduleSelectedEmployeeIds || []).map(String));
 
@@ -2123,6 +2146,10 @@ export const ScheduleManager = {
             const targetDayIndex = parseInt(e.target.closest('td').dataset.day, 10);
 
             const schedule = getActiveSchedule();
+            if (this.isWeekLocked()) {
+                showToast("La semana está bloqueada. Solo podés ver los turnos.", "warning");
+                return;
+            }
             const sourceShift = schedule[sourceDayIndex]?.find(s => s.id === sourceShiftId);
             if (!sourceShift) return;
 

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -56,6 +56,7 @@ const defaultState = {
     scheduleRoleFilters: [],
     scheduleSearchTerm: '',
     scheduleSelectedEmployeeIds: [],
+    scheduleSelectedEmployeeSearch: '',
     breaks: {},
     tempPlanillaState: null,
     rappiCode: '',

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -55,6 +55,7 @@ const defaultState = {
     clockInDateFilter: null,
     scheduleRoleFilters: [],
     scheduleSearchTerm: '',
+    scheduleSelectedEmployeeIds: [],
     breaks: {},
     tempPlanillaState: null,
     rappiCode: '',

--- a/style.css
+++ b/style.css
@@ -145,7 +145,8 @@
   .namecol{position:sticky;left:0;background:#fff;border-right:1px solid var(--border);z-index:5;padding:6px 10px;display:flex;gap:8px;align-items:center}
   .name{font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .stars{display:flex;gap:4px;align-items:center;min-width:0;flex-wrap:wrap}
-  .slot-h{font-size:10px;color:var(--muted);text-align:center;border-left:1px solid var(--border);padding:6px 0}
+.slot-h{font-size:10px;color:var(--muted);text-align:center;border-left:1px solid var(--border);padding:6px 0}
+.slot.hovered-slot-column,.slot-h.hovered-slot-column{box-shadow:inset 0 0 0 9999px rgba(15,23,42,0.06)}
   .all-star-indicator{color: #f59e0b;opacity: 0.5;font-size: 10px;height: 10px;}
   .slot{height:40px;position:relative;cursor:crosshair;user-select:none; padding: 4px 2px;}
   .slot.assigned .label{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:600;color:#fff}


### PR DESCRIPTION
## Summary
- Ajusta la validación de intercambio para ignorar el turno contraparte cuando el intercambio es el mismo día y así revisar otras restricciones relevantes.
- Mantiene la revisión completa de restricciones cuando el intercambio ocurre en días diferentes.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959893dffb4832da6b227f041f3c34c)