### PR TITLE
Admin: add user/store provisioning, per-store settings, configurable scheduling rules, and security updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,27 +21,36 @@ service cloud.firestore {
       return isSignedIn() && allowedStores().hasAny([storeId]);
     }
 
+    function isAdmin() {
+      return userRole() == 'admin';
+    }
+
     match /users/{uid} {
-      allow read: if isSignedIn() && uid == request.auth.uid;
-      allow write: if false;
+      allow read: if isSignedIn() && (uid == request.auth.uid || isAdmin());
+      allow write: if isSignedIn() && isAdmin();
+    }
+
+    match /stores/{storeId} {
+      allow read: if hasStoreAccess(storeId) || isAdmin();
+      allow write: if isAdmin() || (hasStoreAccess(storeId) && userRole() in ['manager', 'admin']);
     }
 
     match /stores/{storeId}/employees/{employeeId} {
-      allow read, write: if hasStoreAccess(storeId) && userRole() in ['manager', 'admin'];
+      allow read, write: if isAdmin() || (hasStoreAccess(storeId) && userRole() in ['manager', 'admin']);
     }
 
     match /stores/{storeId}/schedules/{docId} {
-      allow read, write: if hasStoreAccess(storeId) && userRole() in ['manager', 'admin'];
+      allow read, write: if isAdmin() || (hasStoreAccess(storeId) && userRole() in ['manager', 'admin']);
     }
 
     match /stores/{storeId}/weeks/{weekId} {
-      allow read, write: if hasStoreAccess(storeId) && userRole() in ['manager', 'admin'];
+      allow read, write: if isAdmin() || (hasStoreAccess(storeId) && userRole() in ['manager', 'admin']);
     }
 
     match /stores/{storeId}/solicitudes/{reqId} {
-      allow read: if hasStoreAccess(storeId);
-      allow create: if hasStoreAccess(storeId);
-      allow update, delete: if hasStoreAccess(storeId) && userRole() in ['manager', 'admin'];
+      allow read: if isAdmin() || hasStoreAccess(storeId);
+      allow create: if isAdmin() || hasStoreAccess(storeId);
+      allow update, delete: if isAdmin() || (hasStoreAccess(storeId) && userRole() in ['manager', 'admin']);
     }
   }
 }

--- a/manager.html
+++ b/manager.html
@@ -348,10 +348,39 @@
       </section>
     </div>
 
-    <div id="view-options" class="wrap" style="display:none; max-width: none; padding: 0 16px;">
-      <section class="card">
-        <div class="card-h"><strong>Opciones</strong></div>
-        <div class="card-c stack">
+	    <div id="view-options" class="wrap" style="display:none; max-width: none; padding: 0 16px;">
+	      <section class="card" style="margin-bottom:16px;">
+	        <div class="card-h">
+	          <strong>Configuración del local</strong>
+	          <span class="pill pill-neutral">Por local</span>
+	        </div>
+	        <div class="card-c stack" style="gap:16px;">
+	          <p class="muted" style="margin:0;">
+	            Definí cómo se muestra este local en los impresos y qué restricciones automáticas querés aplicar al armar horarios.
+	          </p>
+	          <form id="store-settings-form" class="admin-user-grid">
+	            <div class="stack">
+	              <label class="muted mini-label" for="store-display-name">Nombre del local para impresión</label>
+	              <input id="store-display-name" class="input" placeholder="Ej: Local Norte" />
+	            </div>
+	            <div class="stack">
+	              <label class="muted mini-label" for="rule-max-consecutive-limit">Máximo de días consecutivos</label>
+	              <input id="rule-max-consecutive-limit" type="number" min="1" class="input" value="5" />
+	            </div>
+	            <label class="pill pill-toggle" style="align-self:end;">
+	              <input id="rule-max-consecutive-enabled" type="checkbox" checked>
+	              Aplicar regla de días consecutivos
+	            </label>
+	            <div class="admin-form-actions">
+	              <button id="btn-save-store-settings" class="btn" type="submit">Guardar configuración</button>
+	              <span class="muted mini-label">Si desactivás esta regla, la autoasignación dejará de bloquear turnos por ese motivo.</span>
+	            </div>
+	          </form>
+	        </div>
+	      </section>
+	      <section class="card">
+	        <div class="card-h"><strong>Opciones</strong></div>
+	        <div class="card-c stack">
           <div class="row" style="flex-wrap:wrap; gap:8px; align-items:flex-end;">
             <div class="stack" style="min-width:200px;">
               <label class="muted mini-label">Nombre del puesto</label>
@@ -367,10 +396,69 @@
             <button id="btn-add-role" class="btn">Agregar</button>
             <button id="btn-reset-roles" class="btn secondary">Restablecer</button>
           </div>
-          <div id="roles-list" class="stack"></div>
-        </div>
-      </section>
-    </div>
+	          <div id="roles-list" class="stack"></div>
+	        </div>
+	      </section>
+	      <section id="admin-user-management" class="card" style="display:none; margin-top:16px;">
+	        <div class="card-h">
+	          <strong>Administración de usuarios y locales</strong>
+	          <span class="pill pill-neutral">Solo admin</span>
+	        </div>
+	        <div class="card-c stack" style="gap:16px;">
+	          <p class="muted" style="margin:0;">
+	            Desde acá podés crear un usuario nuevo y asignarlo a un local existente o crear un local nuevo en el mismo paso.
+	          </p>
+	          <form id="admin-create-user-form" class="admin-user-grid">
+	            <div class="stack">
+	              <label class="muted mini-label" for="admin-user-name">Nombre visible</label>
+	              <input id="admin-user-name" class="input" placeholder="Ej: Laura Pérez" required />
+	            </div>
+	            <div class="stack">
+	              <label class="muted mini-label" for="admin-user-email">Email</label>
+	              <input id="admin-user-email" type="email" class="input" placeholder="usuario@empresa.com" required />
+	            </div>
+	            <div class="stack">
+	              <label class="muted mini-label" for="admin-user-password">Contraseña temporal</label>
+	              <input id="admin-user-password" type="password" class="input" placeholder="Mínimo 6 caracteres" minlength="6" required />
+	            </div>
+	            <div class="stack">
+	              <label class="muted mini-label" for="admin-user-role">Rol</label>
+	              <select id="admin-user-role" class="select">
+	                <option value="manager">Manager</option>
+	                <option value="admin">Admin</option>
+	              </select>
+	            </div>
+	            <div class="stack">
+	              <label class="muted mini-label" for="admin-store-mode">Tipo de asignación</label>
+	              <select id="admin-store-mode" class="select">
+	                <option value="existing">Asignar local existente</option>
+	                <option value="new">Crear local nuevo</option>
+	              </select>
+	            </div>
+	            <div id="admin-existing-store-row" class="stack admin-store-row">
+	              <label class="muted mini-label" for="admin-store-select">Local existente</label>
+	              <select id="admin-store-select" class="select">
+	                <option value="" selected disabled>Cargando locales...</option>
+	              </select>
+	            </div>
+	            <div id="admin-new-store-row" class="admin-store-row admin-store-grid" style="display:none;">
+	              <div class="stack">
+	                <label class="muted mini-label" for="admin-new-store-id">ID del local</label>
+	                <input id="admin-new-store-id" class="input" placeholder="Ej: store-norte" disabled />
+	              </div>
+	              <div class="stack">
+	                <label class="muted mini-label" for="admin-new-store-name">Nombre visible del local</label>
+	                <input id="admin-new-store-name" class="input" placeholder="Ej: Local Norte" disabled />
+	              </div>
+	            </div>
+	            <div class="admin-form-actions">
+	              <button id="admin-create-user-btn" class="btn" type="submit">Crear usuario</button>
+	              <span class="muted mini-label">Si creás un local nuevo, también se agrega a tus locales habilitados para administrarlo.</span>
+	            </div>
+	          </form>
+	        </div>
+	      </section>
+	    </div>
 
     <div id="view-clock-ins" class="wrap" style="display:none; max-width: none; padding: 0 16px;">
       <!-- Fichadas -->

--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,13 @@ export let ROLES = [
 
 export const DEFAULT_ROLES = [...ROLES];
 
+export const DEFAULT_SCHEDULING_RULES = {
+  maxConsecutiveDays: {
+    enabled: true,
+    limit: 5,
+  },
+};
+
 export function setRoles(newRoles = []) {
   ROLES.splice(0, ROLES.length, ...newRoles);
 }

--- a/src/modules/OptionsManager.js
+++ b/src/modules/OptionsManager.js
@@ -3,15 +3,28 @@ import { store } from '../store/Store.js';
 import { ROLES, setRoles, DEFAULT_ROLES } from '../config.js';
 import { DataManager } from '../services/DataManager.js';
 import { showToast, showConfirmDialog } from '../utils/feedback.js';
+import { AdminService } from '../services/AdminService.js';
+import { normalizeSchedulingRules } from '../utils/rules.js';
 
 export const OptionsManager = {
+    adminStores: [],
+
     init() {
         const addBtn = el('#btn-add-role');
         const resetBtn = el('#btn-reset-roles');
         addBtn?.addEventListener('click', () => this.handleAddRole());
         resetBtn?.addEventListener('click', () => this.handleReset());
+        el('#store-settings-form')?.addEventListener('submit', (event) => this.handleStoreSettingsSubmit(event));
+        el('#rule-max-consecutive-enabled')?.addEventListener('change', () => this.renderStoreSettings());
+        el('#admin-create-user-form')?.addEventListener('submit', (event) => this.handleCreateUser(event));
+        el('#admin-store-mode')?.addEventListener('change', () => this.syncAdminStoreMode());
         this.renderRoles();
+        this.renderStoreSettings();
+        this.renderAdminPanel();
         store.subscribe(() => this.renderRoles());
+        store.subscribe(() => this.renderStoreSettings());
+        store.subscribe(() => this.renderAdminPanel());
+        this.loadStores();
     },
 
     getRoles() {
@@ -137,5 +150,194 @@ export const OptionsManager = {
 
             list.appendChild(row);
         });
+    },
+
+    async loadStores() {
+        if (store.getState().currentUser?.role !== 'admin') return;
+        try {
+            this.adminStores = await AdminService.listStores();
+            this.renderAdminStoreOptions();
+        } catch (error) {
+            console.error('No se pudieron cargar los locales.', error);
+            showToast('No se pudieron cargar los locales.', 'warning');
+        }
+    },
+
+    renderAdminPanel() {
+        const wrapper = el('#admin-user-management');
+        if (!wrapper) return;
+        const isAdmin = store.getState().currentUser?.role === 'admin';
+        wrapper.style.display = isAdmin ? 'block' : 'none';
+        if (!isAdmin) return;
+        this.renderAdminStoreOptions();
+        this.syncAdminStoreMode();
+    },
+
+    renderStoreSettings() {
+        const storeNameInput = el('#store-display-name');
+        const consecutiveEnabledInput = el('#rule-max-consecutive-enabled');
+        const consecutiveLimitInput = el('#rule-max-consecutive-limit');
+        if (!storeNameInput || !consecutiveEnabledInput || !consecutiveLimitInput) return;
+
+        const state = store.getState();
+        const rules = normalizeSchedulingRules(state.schedulingRules || {});
+        const safeStoreName = state.storeName || state.activeStoreId || '';
+
+        if (document.activeElement !== storeNameInput) {
+            storeNameInput.value = safeStoreName;
+        }
+        if (document.activeElement !== consecutiveLimitInput) {
+            consecutiveLimitInput.value = String(rules.maxConsecutiveDays.limit);
+        }
+        consecutiveEnabledInput.checked = !!rules.maxConsecutiveDays.enabled;
+        consecutiveLimitInput.disabled = !consecutiveEnabledInput.checked;
+    },
+
+    async handleStoreSettingsSubmit(event) {
+        event.preventDefault();
+        const state = store.getState();
+        if (!state.activeStoreId) {
+            showToast('No hay un local activo para configurar.', 'warning');
+            return;
+        }
+
+        const submitBtn = el('#btn-save-store-settings');
+        const storeName = (el('#store-display-name')?.value || '').trim();
+        const consecutiveEnabled = !!el('#rule-max-consecutive-enabled')?.checked;
+        const consecutiveLimit = Number(el('#rule-max-consecutive-limit')?.value || 0);
+
+        const schedulingRules = normalizeSchedulingRules({
+            maxConsecutiveDays: {
+                enabled: consecutiveEnabled,
+                limit: consecutiveLimit,
+            },
+        });
+
+        if (consecutiveEnabled && (!Number.isFinite(consecutiveLimit) || consecutiveLimit < 1)) {
+            showToast('Ingresá un límite válido de días consecutivos.', 'warning');
+            return;
+        }
+
+        try {
+            if (submitBtn) {
+                submitBtn.disabled = true;
+                submitBtn.textContent = 'Guardando...';
+            }
+
+            store.setState({
+                storeName: storeName || state.activeStoreId,
+                schedulingRules,
+            });
+
+            await DataManager.saveState();
+            showToast('Configuración del local guardada.', 'success');
+        } catch (error) {
+            console.error('Error guardando configuración del local.', error);
+            showToast(error.message || 'No se pudo guardar la configuración.', 'error');
+        } finally {
+            if (submitBtn) {
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Guardar configuración';
+            }
+        }
+    },
+
+    renderAdminStoreOptions() {
+        const select = el('#admin-store-select');
+        if (!select) return;
+        const currentValue = select.value;
+        clear(select);
+
+        select.appendChild(create('option', {
+            value: '',
+            textContent: this.adminStores.length ? 'Seleccioná un local' : 'No hay locales cargados',
+            disabled: true,
+            attrs: this.adminStores.length ? {} : { selected: 'selected' }
+        }));
+
+        this.adminStores.forEach(storeItem => {
+            select.appendChild(create('option', {
+                value: storeItem.id,
+                textContent: `${storeItem.displayName} (${storeItem.id})`,
+                attrs: currentValue === storeItem.id ? { selected: 'selected' } : {}
+            }));
+        });
+
+        if (currentValue && this.adminStores.some(storeItem => storeItem.id === currentValue)) {
+            select.value = currentValue;
+        }
+    },
+
+    syncAdminStoreMode() {
+        const mode = el('#admin-store-mode')?.value || 'existing';
+        const existingRow = el('#admin-existing-store-row');
+        const newRow = el('#admin-new-store-row');
+        const storeSelect = el('#admin-store-select');
+        const newStoreId = el('#admin-new-store-id');
+        const newStoreName = el('#admin-new-store-name');
+
+        if (existingRow) existingRow.style.display = mode === 'existing' ? 'grid' : 'none';
+        if (newRow) newRow.style.display = mode === 'new' ? 'grid' : 'none';
+
+        if (storeSelect) storeSelect.disabled = mode !== 'existing';
+        if (newStoreId) newStoreId.disabled = mode !== 'new';
+        if (newStoreName) newStoreName.disabled = mode !== 'new';
+    },
+
+    async handleCreateUser(event) {
+        event.preventDefault();
+        if (store.getState().currentUser?.role !== 'admin') {
+            showToast('Solo administradores pueden crear usuarios.', 'error');
+            return;
+        }
+
+        const submitBtn = el('#admin-create-user-btn');
+        const mode = el('#admin-store-mode')?.value || 'existing';
+        const displayName = el('#admin-user-name')?.value || '';
+        const email = el('#admin-user-email')?.value || '';
+        const password = el('#admin-user-password')?.value || '';
+        const role = el('#admin-user-role')?.value || 'manager';
+        const storeId = mode === 'new'
+            ? (el('#admin-new-store-id')?.value || '')
+            : (el('#admin-store-select')?.value || '');
+        const storeName = mode === 'new' ? (el('#admin-new-store-name')?.value || '') : '';
+
+        try {
+            if (submitBtn) {
+                submitBtn.disabled = true;
+                submitBtn.textContent = 'Creando...';
+            }
+
+            const result = await AdminService.createUserWithStore({
+                displayName,
+                email,
+                password,
+                role,
+                storeId,
+                createNewStore: mode === 'new',
+                storeName,
+            });
+
+            showToast(
+                result.createdStore
+                    ? `Usuario creado y local ${result.storeId} inicializado.`
+                    : `Usuario creado para el local ${result.storeId}.`,
+                'success'
+            );
+
+            el('#admin-create-user-form')?.reset();
+            el('#admin-user-role') && (el('#admin-user-role').value = 'manager');
+            el('#admin-store-mode') && (el('#admin-store-mode').value = 'existing');
+            this.syncAdminStoreMode();
+            await this.loadStores();
+        } catch (error) {
+            console.error('Error creando usuario/local.', error);
+            showToast(error.message || 'No se pudo crear el usuario.', 'error', 5000);
+        } finally {
+            if (submitBtn) {
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Crear usuario';
+            }
+        }
     }
 };

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -9,7 +9,8 @@ import {
     checkEmployeeAvailability,
     isDateInSanctionPeriod,
     calculateConsecutiveWorkDays,
-    isSlotUnavailable
+    isSlotUnavailable,
+    getSchedulingRules
 } from '../utils/rules.js';
 import { getMonday, toISODateString } from '../utils/date.js';
 import { EmployeeManager } from './EmployeeManager.js';
@@ -19,6 +20,10 @@ export const ScheduleManager = {
     swapShiftSelectionId: null,
     activeTooltipEl: null,
     activeTooltipAnchor: null,
+    getActiveStoreLabel() {
+        const state = store.getState();
+        return (state.storeName || state.activeStoreId || 'Local sin nombre').trim();
+    },
     init() {
         this.bindEvents();
     },
@@ -988,14 +993,16 @@ export const ScheduleManager = {
 
     printSchedule() {
         const schedule = getActiveSchedule();
-        const employees = store.getState().employees
+        const state = store.getState();
+        const employees = state.employees
             .filter(emp => this.getEmployeeWeeklyHours(emp.id) > 0)
             .sort((a,b) => a.name.localeCompare(b.name));
 
-        const monday = new Date(store.getState().activeWeek + "T12:00:00Z");
+        const monday = new Date(state.activeWeek + "T12:00:00Z");
         const sunday = new Date(monday);
         sunday.setDate(monday.getDate() + 6);
         const formatDate = (d) => `${String(d.getDate()).padStart(2,'0')}/${String(d.getMonth()+1).padStart(2,'0')}/${d.getFullYear()}`;
+        const storeLabel = this.escapeHtml(this.getActiveStoreLabel());
 
         let tableRows = '';
         employees.forEach(emp => {
@@ -1016,7 +1023,7 @@ export const ScheduleManager = {
         });
 
         const w = window.open('', '', 'height=800,width=1200');
-        w.document.write(`<html><head><title>Horarios</title><style>body{font-family:sans-serif;font-size:10px}table{width:100%;border-collapse:collapse}th,td{border:1px solid #ccc;padding:5px;text-align:center}th{background:#f2f2f2}@media print{body{margin:0.5in}}</style></head><body><h2>KFC LA PLATA - Semana ${formatDate(monday)} al ${formatDate(sunday)}</h2><table><thead><tr><th>Nombre</th>${DAYS.map(d=>`<th>${d}</th>`).join('')}</tr></thead><tbody>${tableRows}</tbody></table><script>setTimeout(()=>{window.print();window.close()},500)</script></body></html>`);
+        w.document.write(`<html><head><title>Horarios</title><style>body{font-family:sans-serif;font-size:10px}table{width:100%;border-collapse:collapse}th,td{border:1px solid #ccc;padding:5px;text-align:center}th{background:#f2f2f2}@media print{body{margin:0.5in}}</style></head><body><h2>${storeLabel} - Semana ${formatDate(monday)} al ${formatDate(sunday)}</h2><table><thead><tr><th>Nombre</th>${DAYS.map(d=>`<th>${d}</th>`).join('')}</tr></thead><tbody>${tableRows}</tbody></table><script>setTimeout(()=>{window.print();window.close()},500)</script></body></html>`);
         w.document.close();
     },
 
@@ -1026,6 +1033,7 @@ export const ScheduleManager = {
         const employees = state.employees;
         const weekMonday = new Date(state.activeWeek + "T12:00:00Z");
         const weekTickets = state.projectedTickets[state.activeWeek] || {};
+        const storeLabel = this.escapeHtml(this.getActiveStoreLabel());
         let pagesHtml = '';
 
         const getEmployeeColor = (id) => {
@@ -1082,7 +1090,7 @@ export const ScheduleManager = {
             let timelineHeader = '';
             SLOTS.forEach(slot => timelineHeader += `<th>${slot.label.split(':')[0]}</th>`);
 
-            pagesHtml += `<div class="page" style="page-break-after:always; margin-bottom: 20px;"><div style="display:flex;align-items:baseline;gap:12px;"><h3 style="margin:4px 0">${formattedDate}</h3><span style="font-size:11px;color:#555;white-space:nowrap;">${statsLabel}</span></div><table style="width:100%;border-collapse:collapse;font-size:9px"><thead>${headcountRow}<tr><th>Empleado</th><th>Pos</th><th>Hs</th>${timelineHeader}</tr></thead><tbody>${tableRows}</tbody></table></div>`;
+            pagesHtml += `<div class="page" style="page-break-after:always; margin-bottom: 20px;"><div style="display:flex;justify-content:space-between;align-items:baseline;gap:12px;"><div style="display:flex;align-items:baseline;gap:12px;"><h3 style="margin:4px 0">${formattedDate}</h3><span style="font-size:11px;color:#555;white-space:nowrap;">${statsLabel}</span></div><span style="font-size:12px;font-weight:600;color:#222;white-space:nowrap;">${storeLabel}</span></div><table style="width:100%;border-collapse:collapse;font-size:9px"><thead>${headcountRow}<tr><th>Empleado</th><th>Pos</th><th>Hs</th>${timelineHeader}</tr></thead><tbody>${tableRows}</tbody></table></div>`;
         }
 
         const w = window.open('', '', 'height=800,width=1200');
@@ -1884,9 +1892,10 @@ export const ScheduleManager = {
              const restCheck = checkRestTime(emp.id, shift, state.activeWeek, day);
              if (!restCheck.pass) return false;
 
-             // 7. Consecutive Days (soft check - we avoid > 5 in auto assign)
+             // 7. Consecutive Days (configurable per local)
+             const consecutiveRule = getSchedulingRules().maxConsecutiveDays;
              const consec = calculateConsecutiveWorkDays(emp.id, state.activeWeek, day);
-             if (consec > 5) return false;
+             if (consecutiveRule.enabled && consec > consecutiveRule.limit) return false;
 
              return true;
         }
@@ -1997,8 +2006,11 @@ export const ScheduleManager = {
                 const availCheck = checkEmployeeAvailability(emp, shift, state.activeWeek, day);
                 if(!availCheck.isAvailable) softWarnings.push(availCheck.reason);
 
+                const consecutiveRule = getSchedulingRules().maxConsecutiveDays;
                 const consec = calculateConsecutiveWorkDays(emp.id, state.activeWeek, day);
-                if(consec > 5) softWarnings.push(`Trabajará ${consec} días seguidos.`);
+                if (consecutiveRule.enabled && consec > consecutiveRule.limit) {
+                    softWarnings.push(`Trabajará ${consec} días seguidos (límite ${consecutiveRule.limit}).`);
+                }
 
                 return { hardWarning, softWarnings };
             };

--- a/src/services/AdminService.js
+++ b/src/services/AdminService.js
@@ -1,0 +1,170 @@
+import { firebaseConfig, ROLES } from '../config.js';
+import { store } from '../store/Store.js';
+import { getDb } from './firebase.js';
+import { storeDoc, storeSchedulesRef, userDocRef } from './firestoreRefs.js';
+
+const SECONDARY_APP_NAME = 'admin-user-provisioning';
+
+function ensureAdmin() {
+  const currentUser = store.getState().currentUser;
+  if (!currentUser || currentUser.role !== 'admin') {
+    throw new Error('Solo un administrador puede crear usuarios o locales.');
+  }
+  return currentUser;
+}
+
+function getSecondaryApp() {
+  const existing = firebase.apps.find(app => app.name === SECONDARY_APP_NAME);
+  return existing || firebase.initializeApp(firebaseConfig, SECONDARY_APP_NAME);
+}
+
+function cleanupStoreIds(storeIds = []) {
+  return [...new Set(
+    storeIds
+      .map(value => String(value || '').trim())
+      .filter(Boolean)
+  )];
+}
+
+async function rollbackCreatedUser(authInstance) {
+  try {
+    if (authInstance?.currentUser) {
+      await authInstance.currentUser.delete();
+    }
+  } catch (error) {
+    console.error('No se pudo revertir el usuario creado en Auth.', error);
+  } finally {
+    try {
+      await authInstance?.signOut();
+    } catch (error) {
+      console.error('No se pudo cerrar la sesión secundaria.', error);
+    }
+  }
+}
+
+export const AdminService = {
+  async listStores() {
+    ensureAdmin();
+    const snapshot = await getDb().collection('stores').get();
+    return snapshot.docs
+      .map((doc) => ({
+        id: doc.id,
+        displayName: doc.data()?.displayName || doc.id,
+      }))
+      .sort((a, b) => a.displayName.localeCompare(b.displayName, 'es'));
+  },
+
+  async createUserWithStore({
+    displayName,
+    email,
+    password,
+    role,
+    storeId,
+    createNewStore = false,
+    storeName = '',
+  }) {
+    const currentUser = ensureAdmin();
+    const cleanDisplayName = String(displayName || '').trim();
+    const cleanEmail = String(email || '').trim().toLowerCase();
+    const cleanPassword = String(password || '');
+    const cleanRole = role === 'admin' ? 'admin' : 'manager';
+    const cleanStoreId = String(storeId || '').trim();
+    const cleanStoreName = String(storeName || '').trim();
+
+    if (!cleanDisplayName) throw new Error('Ingresá el nombre visible del usuario.');
+    if (!cleanEmail) throw new Error('Ingresá un email válido.');
+    if (cleanPassword.length < 6) throw new Error('La contraseña temporal debe tener al menos 6 caracteres.');
+    if (!cleanStoreId) throw new Error('Seleccioná o ingresá un local.');
+
+    const db = getDb();
+    const finalAllowedStores = cleanupStoreIds([cleanStoreId]);
+
+    if (createNewStore) {
+      const existingStore = await storeDoc(cleanStoreId).get();
+      if (existingStore.exists) {
+        throw new Error('Ya existe un local con ese ID.');
+      }
+    } else {
+      const existingStore = await storeDoc(cleanStoreId).get();
+      if (!existingStore.exists) {
+        throw new Error('El local seleccionado no existe.');
+      }
+    }
+
+    const secondaryApp = getSecondaryApp();
+    const secondaryAuth = secondaryApp.auth();
+    let createdCredential = null;
+
+    try {
+      createdCredential = await secondaryAuth.createUserWithEmailAndPassword(cleanEmail, cleanPassword);
+      const newUser = createdCredential.user;
+      if (!newUser) throw new Error('No se pudo crear la cuenta en Authentication.');
+
+      const batch = db.batch();
+      const userPayload = {
+        displayName: cleanDisplayName,
+        allowedStores: finalAllowedStores,
+        defaultStore: cleanStoreId,
+        role: cleanRole,
+        email: cleanEmail,
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+        createdBy: currentUser.uid,
+      };
+
+      batch.set(userDocRef(newUser.uid), userPayload, { merge: true });
+
+      if (createNewStore) {
+        batch.set(storeDoc(cleanStoreId), {
+          displayName: cleanStoreName || cleanStoreId,
+          createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+          createdBy: currentUser.uid,
+        }, { merge: true });
+
+        batch.set(storeSchedulesRef(cleanStoreId).doc('main'), {
+          templates: {},
+          projectedTickets: {},
+          breaks: {},
+          roles: store.getState().roles?.length ? store.getState().roles : ROLES,
+          rappiCode: '',
+          initializedAt: firebase.firestore.FieldValue.serverTimestamp(),
+          initializedBy: currentUser.uid,
+        }, { merge: true });
+
+        const currentAllowedStores = cleanupStoreIds([
+          ...(store.getState().currentUser?.allowedStores || []),
+          cleanStoreId,
+        ]);
+
+        batch.set(userDocRef(currentUser.uid), {
+          allowedStores: currentAllowedStores,
+        }, { merge: true });
+      }
+
+      await batch.commit();
+
+      if (createNewStore) {
+        const currentProfile = store.getState().currentUser || {};
+        store.setState({
+          currentUser: {
+            ...currentProfile,
+            allowedStores: cleanupStoreIds([...(currentProfile.allowedStores || []), cleanStoreId]),
+          },
+        });
+      }
+
+      await secondaryAuth.signOut();
+
+      return {
+        uid: newUser.uid,
+        email: cleanEmail,
+        storeId: cleanStoreId,
+        createdStore: createNewStore,
+      };
+    } catch (error) {
+      if (createdCredential?.user) {
+        await rollbackCreatedUser(secondaryAuth);
+      }
+      throw error;
+    }
+  },
+};

--- a/src/services/DataManager.js
+++ b/src/services/DataManager.js
@@ -7,10 +7,12 @@ import {
     legacyEmployeesRef,
     legacySchedulesRef,
     legacyWeeksRef,
+    storeDoc,
     storeEmployeesRef,
     storeSchedulesRef,
     storeWeeksRef
 } from './firestoreRefs.js';
+import { normalizeSchedulingRules } from '../utils/rules.js';
 
 function getMonday(d) {
     d = new Date(d);
@@ -41,10 +43,14 @@ export const DataManager = {
             const schedulesRef = storeSchedulesRef(storeId);
             const employeesRef = storeEmployeesRef(storeId);
             const weeksRef = storeWeeksRef(storeId);
+            const storeRootRef = storeDoc(storeId);
 
             // 1. Load Main Doc (Settings, Templates, etc.)
             const mainDocRef = schedulesRef.doc("main");
-            const mainDoc = await mainDocRef.get();
+            const [mainDoc, storeRootSnap] = await Promise.all([
+                mainDocRef.get(),
+                storeRootRef.get(),
+            ]);
 
             // 2. Load Employees
             const employeesSnapshot = await employeesRef.get();
@@ -126,6 +132,8 @@ export const DataManager = {
                 newState.rappiCode = data.rappiCode || '';
                 newState.templates = data.templates || {};
                 newState.projectedTickets = data.projectedTickets || {};
+                newState.storeName = (storeRootSnap.data()?.displayName || data.storeName || storeId || '').trim();
+                newState.schedulingRules = normalizeSchedulingRules(data.schedulingRules || {});
 
                 // Initialize active week
                 if (!newState.activeWeek) {
@@ -167,6 +175,8 @@ export const DataManager = {
                  newState.employees = employeesArray;
                  setRoles(DEFAULT_ROLES);
                  newState.roles = [...ROLES];
+                 newState.storeName = (storeRootSnap.data()?.displayName || storeId || '').trim();
+                 newState.schedulingRules = normalizeSchedulingRules();
             }
 
             store.setState(newState);
@@ -192,6 +202,7 @@ export const DataManager = {
         const schedulesRef = storeSchedulesRef(storeId);
         const employeesRef = storeEmployeesRef(storeId);
         const weeksRef = storeWeeksRef(storeId);
+        const storeRootRef = storeDoc(storeId);
         const activeWeek = state.activeWeek;
         const currentSchedule = state.schedules[activeWeek];
 
@@ -208,8 +219,15 @@ export const DataManager = {
                 breaks: state.breaks,
                 rappiCode: state.rappiCode,
                 roles: state.roles && state.roles.length ? state.roles : ROLES,
+                storeName: (state.storeName || storeId || '').trim(),
+                schedulingRules: normalizeSchedulingRules(state.schedulingRules || {}),
             };
-            await schedulesRef.doc("main").set(mainData, { merge: true });
+            await Promise.all([
+                schedulesRef.doc("main").set(mainData, { merge: true }),
+                storeRootRef.set({
+                    displayName: (state.storeName || storeId || '').trim() || storeId,
+                }, { merge: true }),
+            ]);
 
             const batch = db.batch();
             let opCount = 0;

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -75,7 +75,10 @@ function updateBannerLabels() {
   const userLbl = document.getElementById('session-user-label');
   const storeLbl = document.getElementById('session-store-label');
   if (userLbl) userLbl.textContent = state.currentUser?.displayName || state.currentUser?.email || 'Sin usuario';
-  if (storeLbl) storeLbl.textContent = state.activeStoreId ? `Local activo: ${state.activeStoreId}` : 'Sin local activo';
+  if (storeLbl) {
+    const activeLabel = state.storeName || state.activeStoreId;
+    storeLbl.textContent = activeLabel ? `Local activo: ${activeLabel}` : 'Sin local activo';
+  }
 }
 
 export const SessionService = {
@@ -130,7 +133,7 @@ export const SessionService = {
           };
           const handleSelect = (storeId) => {
             localStorage.setItem(STORAGE_KEY, storeId);
-            store.setState({ activeStoreId: storeId, schedules: {}, employees: [] });
+            store.setState({ activeStoreId: storeId, schedules: {}, employees: [], storeName: '', schedulingRules: null });
             hideSelectionUI();
             updateBannerLabels();
             document.dispatchEvent(new CustomEvent('store-changed', { detail: { storeId } }));

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -61,6 +61,8 @@ const defaultState = {
     tempPlanillaState: null,
     rappiCode: '',
     roles: [...ROLES],
+    storeName: '',
+    schedulingRules: null,
     // Data loaded flags
     isLoading: true,
 };

--- a/src/utils/rules.js
+++ b/src/utils/rules.js
@@ -1,4 +1,4 @@
-import { SLOTS, MAX_SLOT_FOR_MINOR } from '../config.js';
+import { SLOTS, MAX_SLOT_FOR_MINOR, DEFAULT_SCHEDULING_RULES } from '../config.js';
 import { toISODateString, getMonday } from '../utils/date.js';
 import { store, getActiveSchedule } from '../store/Store.js';
 
@@ -168,6 +168,21 @@ export function calculateConsecutiveWorkDays(employeeId, weekId, dayIndex) {
         }
     }
     return consecutiveDays;
+}
+
+export function normalizeSchedulingRules(rules = {}) {
+    const defaultLimit = DEFAULT_SCHEDULING_RULES.maxConsecutiveDays.limit;
+    const rawLimit = Number(rules?.maxConsecutiveDays?.limit);
+    return {
+        maxConsecutiveDays: {
+            enabled: rules?.maxConsecutiveDays?.enabled !== false,
+            limit: Number.isFinite(rawLimit) && rawLimit > 0 ? Math.floor(rawLimit) : defaultLimit,
+        },
+    };
+}
+
+export function getSchedulingRules() {
+    return normalizeSchedulingRules(store.getState().schedulingRules || {});
 }
 
 export function isSlotUnavailable(employee, slotIndex, weekId, dayIndex) {

--- a/style.css
+++ b/style.css
@@ -232,6 +232,30 @@
   font-size: 12px;
 }
 
+.admin-user-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.admin-store-row {
+  min-width: 0;
+}
+
+.admin-store-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.admin-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  grid-column: 1 / -1;
+}
+
 body.dark-mode .pilltab.active {
   background: var(--ink);
   color: var(--card);


### PR DESCRIPTION
### Motivation
- Provide administrators with the ability to create users and initialize new stores from the UI and manage store-level configuration.
- Introduce per-store display names and scheduling rules (notably the max consecutive days rule) so scheduling logic can be configured per store.
- Ensure admins have the necessary Firestore permissions and include the store label on printed schedules for clarity.

### Description
- Added a new `AdminService` (`src/services/AdminService.js`) that provisions users and optionally creates a new store using a secondary Firebase app via `createUserWithStore` and `listStores`.
- Extended Firestore security rules (`firestore.rules`) with `isAdmin()` and broadened admin privileges for `users`, `stores`, and subcollections so admins can read/write/manage as expected.
- UI and UX updates in `manager.html`, `style.css`, and `src/modules/OptionsManager.js` to add a per-store settings panel, admin user/store creation form, store settings persistence, and related CSS/layout (`.admin-user-grid`, `.admin-form-actions`, etc.).
- Persist and load store-level metadata: updated `DataManager` to read/write `storeName` and `schedulingRules` from `stores/{id}` and `schedules/main`, and set defaults when missing; added `DEFAULT_SCHEDULING_RULES` to `src/config.js`.
- Scheduling logic enhancements: added `normalizeSchedulingRules` and `getSchedulingRules` in `src/utils/rules.js` and updated `ScheduleManager` to consult the configured `maxConsecutiveDays` rule when auto-assigning and warning about consecutive days.
- Minor session improvement: `SessionService` now shows the configured `storeName` in the session banner instead of the raw store ID.
- Printing behavior updated to include the active store label in both weekly and daily printouts (`ScheduleManager.printSchedule` and `printDailyPlanning`).

### Testing
- Performed a project build with `npm run build` which completed successfully.
- Ran the existing automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b7fc6b08832d9612eac2c62be75c)