### PR TITLE
Soporte por local para planificación semanal / quincenal / mensual

### DIFF
--- a/manager.html
+++ b/manager.html
@@ -316,6 +316,34 @@
                     <div id="tbody"></div>
                 </div>
             </div>
+
+            <div id="monthly-planner-section" class="card-c stack" style="display:none;">
+              <div class="row" style="justify-content:space-between; align-items:flex-end; gap:12px; flex-wrap:wrap;">
+                <div class="stack" style="min-width:220px;">
+                  <label class="muted mini-label" for="monthly-planner-month">Mes a planificar</label>
+                  <input id="monthly-planner-month" type="month" class="input input-compact" />
+                </div>
+                <span class="muted mini-label">Hacé click en una celda para cargar horario (entrada/salida) y puesto.</span>
+              </div>
+              <div id="monthly-planner-editor" class="row" style="display:none; gap:8px; align-items:flex-end; flex-wrap:wrap;">
+                <span id="monthly-editor-target" class="pill pill-neutral"></span>
+                <div class="stack">
+                  <label class="muted mini-label" for="monthly-editor-role">Puesto</label>
+                  <select id="monthly-editor-role" class="select input-compact"></select>
+                </div>
+                <div class="stack">
+                  <label class="muted mini-label" for="monthly-editor-start">Entrada</label>
+                  <select id="monthly-editor-start" class="select input-compact"></select>
+                </div>
+                <div class="stack">
+                  <label class="muted mini-label" for="monthly-editor-end">Salida</label>
+                  <select id="monthly-editor-end" class="select input-compact"></select>
+                </div>
+                <button id="monthly-editor-save" class="btn">Guardar celda</button>
+                <button id="monthly-editor-clear" class="btn secondary">Marcar OFF</button>
+              </div>
+              <div id="monthly-planner-grid"></div>
+            </div>
         </section>
     </div>
 

--- a/manager.html
+++ b/manager.html
@@ -363,6 +363,14 @@
 	              <label class="muted mini-label" for="store-display-name">Nombre del local para impresión</label>
 	              <input id="store-display-name" class="input" placeholder="Ej: Local Norte" />
 	            </div>
+	            <div class="stack">
+	              <label class="muted mini-label" for="store-scheduling-period">Metodología para armar/pasar horarios</label>
+	              <select id="store-scheduling-period" class="select">
+	                <option value="1">Semanal (7 días)</option>
+	                <option value="2">Quincenal (14 días)</option>
+	                <option value="4">Mensual (28 días)</option>
+	              </select>
+	            </div>
 	            <label class="pill pill-toggle" style="align-self:end;">
 	              <input id="rule-enforce-sanctions" type="checkbox" checked>
 	              Bloquear por licencias/sanciones

--- a/manager.html
+++ b/manager.html
@@ -336,8 +336,17 @@
                   <select id="monthly-editor-start" class="select input-compact"></select>
                 </div>
                 <div class="stack">
-                  <label class="muted mini-label" for="monthly-editor-end">Salida</label>
-                  <select id="monthly-editor-end" class="select input-compact"></select>
+                  <label class="muted mini-label" for="monthly-editor-duration">Duración del turno</label>
+                  <select id="monthly-editor-duration" class="select input-compact">
+                    <option value="">--</option>
+                    <option value="4">4 hs</option>
+                    <option value="5">5 hs</option>
+                    <option value="6">6 hs</option>
+                    <option value="7">7 hs</option>
+                    <option value="8">8 hs</option>
+                    <option value="9">9 hs</option>
+                    <option value="10">10 hs</option>
+                  </select>
                 </div>
                 <button id="monthly-editor-save" class="btn">Guardar celda</button>
                 <button id="monthly-editor-clear" class="btn secondary">Marcar OFF</button>

--- a/manager.html
+++ b/manager.html
@@ -734,7 +734,7 @@
         <div class="card">
             <div class="card-h">
                 <div class="stack" style="gap: 0;">
-                    <strong>Resumen Semanal</strong>
+                    <strong id="summary-modal-heading">Resumen Semanal</strong>
                     <h4 id="weekly-summary-title" class="muted" style="margin:0;font-weight:normal;font-size:13px;"></h4>
                 </div>
                 <div class="row" style="margin-left: 16px; align-items: center; gap: 8px;">

--- a/manager.html
+++ b/manager.html
@@ -56,6 +56,7 @@
         <button id="btn-prev-week" class="btn secondary">◄</button>
         <button id="week-display" class="btn secondary"></button>
         <button id="btn-next-week" class="btn secondary">►</button>
+        <input id="monthly-top-month" type="month" class="input input-compact" style="display:none; min-width:170px;" />
       </div>
 
       <div class="row main-bar-right">
@@ -318,13 +319,6 @@
             </div>
 
             <div id="monthly-planner-section" class="card-c stack" style="display:none;">
-              <div class="row" style="justify-content:space-between; align-items:flex-end; gap:12px; flex-wrap:wrap;">
-                <div class="stack" style="min-width:220px;">
-                  <label class="muted mini-label" for="monthly-planner-month">Mes a planificar</label>
-                  <input id="monthly-planner-month" type="month" class="input input-compact" />
-                </div>
-                <span class="muted mini-label">Hacé click en una celda para cargar horario (entrada/salida) y puesto.</span>
-              </div>
               <div id="monthly-planner-editor" class="row" style="display:none; gap:8px; align-items:flex-end; flex-wrap:wrap;">
                 <span id="monthly-editor-target" class="pill pill-neutral"></span>
                 <div class="stack">

--- a/manager.html
+++ b/manager.html
@@ -336,6 +336,13 @@
                   <select id="monthly-editor-start" class="select input-compact"></select>
                 </div>
                 <div class="stack">
+                  <label class="muted mini-label" for="monthly-editor-method">Método de carga</label>
+                  <select id="monthly-editor-method" class="select input-compact">
+                    <option value="duration">Entrada + duración</option>
+                    <option value="end">Entrada + salida</option>
+                  </select>
+                </div>
+                <div id="monthly-editor-duration-wrap" class="stack">
                   <label class="muted mini-label" for="monthly-editor-duration">Duración del turno</label>
                   <select id="monthly-editor-duration" class="select input-compact">
                     <option value="">--</option>
@@ -347,6 +354,10 @@
                     <option value="9">9 hs</option>
                     <option value="10">10 hs</option>
                   </select>
+                </div>
+                <div id="monthly-editor-end-wrap" class="stack" style="display:none;">
+                  <label class="muted mini-label" for="monthly-editor-end">Salida</label>
+                  <select id="monthly-editor-end" class="select input-compact"></select>
                 </div>
                 <button id="monthly-editor-save" class="btn">Guardar celda</button>
                 <button id="monthly-editor-clear" class="btn secondary">Marcar OFF</button>

--- a/src/modules/OptionsManager.js
+++ b/src/modules/OptionsManager.js
@@ -185,6 +185,7 @@ export const OptionsManager = {
         const restHoursInput = el('#rule-min-rest-hours');
         const consecutiveEnabledInput = el('#rule-max-consecutive-enabled');
         const consecutiveLimitInput = el('#rule-max-consecutive-limit');
+        const periodInput = el('#store-scheduling-period');
         if (!storeNameInput || !consecutiveEnabledInput || !consecutiveLimitInput || !restHoursInput) return;
 
         const state = store.getState();
@@ -209,6 +210,10 @@ export const OptionsManager = {
         consecutiveEnabledInput.checked = !!rules.maxConsecutiveDays.enabled;
         consecutiveLimitInput.disabled = !consecutiveEnabledInput.checked;
         restHoursInput.disabled = !(restInput?.checked);
+        if (periodInput) {
+            const periodWeeks = [1, 2, 4].includes(Number(state.schedulingPeriodWeeks)) ? Number(state.schedulingPeriodWeeks) : 1;
+            periodInput.value = String(periodWeeks);
+        }
     },
 
     async handleStoreSettingsSubmit(event) {
@@ -230,6 +235,7 @@ export const OptionsManager = {
         const minRestHours = Number(el('#rule-min-rest-hours')?.value || 0);
         const consecutiveEnabled = !!el('#rule-max-consecutive-enabled')?.checked;
         const consecutiveLimit = Number(el('#rule-max-consecutive-limit')?.value || 0);
+        const schedulingPeriodWeeks = Number(el('#store-scheduling-period')?.value || 1);
 
         const schedulingRules = normalizeSchedulingRules({
             enforceSanctions,
@@ -253,6 +259,10 @@ export const OptionsManager = {
             showToast('Ingresá una cantidad válida de horas mínimas de descanso.', 'warning');
             return;
         }
+        if (![1, 2, 4].includes(schedulingPeriodWeeks)) {
+            showToast('Seleccioná una metodología válida (semanal, quincenal o mensual).', 'warning');
+            return;
+        }
 
         try {
             if (submitBtn) {
@@ -263,6 +273,7 @@ export const OptionsManager = {
             store.setState({
                 storeName: storeName || state.activeStoreId,
                 schedulingRules,
+                schedulingPeriodWeeks,
             });
 
             await DataManager.saveState();

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -186,7 +186,7 @@ export const ScheduleManager = {
 
         // Templates
         el("#btnSaveTemplate")?.addEventListener("click", () => this.saveCurrentDayAsTemplate());
-        el("#monthly-planner-month")?.addEventListener("change", (e) => {
+        el("#monthly-top-month")?.addEventListener("change", (e) => {
             this.monthlySelectedMonth = e.target.value;
             this.renderMonthlyPlanner();
         });
@@ -453,6 +453,14 @@ export const ScheduleManager = {
         const dayTitle = el("#day-title");
         const projectedTickets = el("#projectedTickets");
         const suggestBtn = el("#btn-suggest-productivity");
+        const controlsLeft = document.querySelector("#view-schedule .controls-left");
+        const controlsCenter = document.querySelector("#view-schedule .controls-center");
+        const controlsRight = document.querySelector("#view-schedule .controls-right");
+        const monthTopInput = el("#monthly-top-month");
+        const btnLock = el("#btn-lock-week");
+        const btnPrev = el("#btn-prev-week");
+        const btnNext = el("#btn-next-week");
+        const weekDisplay = el("#week-display");
 
         if (monthlySection) monthlySection.style.display = isMonthlyMode ? "flex" : "none";
         if (scroller) scroller.style.display = isMonthlyMode ? "none" : "block";
@@ -460,6 +468,14 @@ export const ScheduleManager = {
         if (dayTitle) dayTitle.style.display = isMonthlyMode ? "none" : "block";
         if (projectedTickets) projectedTickets.disabled = isMonthlyMode;
         if (suggestBtn) suggestBtn.style.display = isMonthlyMode ? "none" : "inline-flex";
+        if (controlsLeft) controlsLeft.style.display = isMonthlyMode ? "none" : "flex";
+        if (controlsCenter) controlsCenter.style.display = isMonthlyMode ? "none" : "flex";
+        if (controlsRight) controlsRight.style.display = isMonthlyMode ? "none" : "flex";
+        if (monthTopInput) monthTopInput.style.display = isMonthlyMode ? "inline-flex" : "none";
+        if (btnLock) btnLock.style.display = isMonthlyMode ? "none" : "inline-flex";
+        if (btnPrev) btnPrev.style.display = isMonthlyMode ? "none" : "inline-flex";
+        if (btnNext) btnNext.style.display = isMonthlyMode ? "none" : "inline-flex";
+        if (weekDisplay) weekDisplay.style.display = isMonthlyMode ? "none" : "inline-flex";
     },
 
     // --- Template Logic ---
@@ -1183,7 +1199,7 @@ export const ScheduleManager = {
 
     async renderMonthlyPlanner() {
         if (this.getSchedulingPeriodWeeks() !== 4) return;
-        const monthInput = el("#monthly-planner-month");
+        const monthInput = el("#monthly-top-month");
         const gridContainer = el("#monthly-planner-grid");
         const editor = el("#monthly-planner-editor");
         const targetBadge = el("#monthly-editor-target");

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1272,13 +1272,13 @@ export const ScheduleManager = {
         table.appendChild(tbody);
         gridContainer.appendChild(table);
 
+        editor.style.display = "flex";
         if (this.monthlyEditorContext) {
             const selectedEmployee = state.employees.find((emp) => emp.id === this.monthlyEditorContext.employeeId);
             const selectedDate = new Date(`${this.monthlyEditorContext.dateISO}T12:00:00.000Z`);
             targetBadge.textContent = `${selectedEmployee?.name || 'Empleado'} · ${selectedDate.toLocaleDateString('es-AR', { timeZone: 'UTC' })}`;
-            editor.style.display = "flex";
         } else {
-            editor.style.display = "none";
+            targetBadge.textContent = "Seleccioná una celda para asignar turno";
         }
     },
 
@@ -1376,6 +1376,11 @@ export const ScheduleManager = {
         const { weekId, dayIndex } = this.getWeekAndDayFromDate(date);
         await DataManager.getWeekData(weekId);
         if (shiftData) {
+            const blockingMessage = this.getMonthlyBlockingValidation(context, shiftData);
+            if (blockingMessage) {
+                showToast(blockingMessage, "error");
+                return false;
+            }
             const warnings = this.getMonthlyShiftWarnings(context, shiftData, weekId, dayIndex);
             if (warnings.length) {
                 const confirmed = await showConfirmDialog({
@@ -1408,6 +1413,17 @@ export const ScheduleManager = {
         await DataManager.saveWeek(weekId);
         this.renderMonthlyPlanner();
         return true;
+    },
+
+    getMonthlyBlockingValidation(context, shiftData) {
+        const state = store.getState();
+        const employee = state.employees.find((emp) => emp.id === context.employeeId);
+        if (!employee) return "Empleado no encontrado.";
+        const rules = getSchedulingRules();
+        if (rules.enforceRoleStar && shiftData.role && !(employee.stars || []).includes(shiftData.role)) {
+            return `El empleado no tiene la estrella requerida para ${shiftData.role}.`;
+        }
+        return "";
     },
 
     getMonthlyShiftWarnings(context, shiftData, weekId, dayIndex) {
@@ -1450,7 +1466,10 @@ export const ScheduleManager = {
 
     async saveMonthlyEditorCell() {
         const context = this.monthlyEditorContext;
-        if (!context) return;
+        if (!context) {
+            showToast("Primero seleccioná una celda en la grilla.", "warning");
+            return;
+        }
         const role = el("#monthly-editor-role")?.value || '';
         const startSlot = Number(el("#monthly-editor-start")?.value);
         const method = el("#monthly-editor-method")?.value === 'end' ? 'end' : 'duration';

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -192,6 +192,10 @@ export const ScheduleManager = {
         });
         el("#monthly-editor-save")?.addEventListener("click", () => this.saveMonthlyEditorCell());
         el("#monthly-editor-clear")?.addEventListener("click", () => this.clearMonthlyEditorCell());
+        el("#monthly-editor-method")?.addEventListener("change", (e) => {
+            this.monthlyTimeMethod = e.target.value === 'end' ? 'end' : 'duration';
+            this.syncMonthlyEditorMethodUI();
+        });
         document.addEventListener("keydown", (e) => this.handleMonthlyKeyboardShortcuts(e));
         document.addEventListener("click", (e) => {
             const menu = document.querySelector('.monthly-context-menu');
@@ -282,6 +286,14 @@ export const ScheduleManager = {
         const weekSchedule = store.getState().schedules[weekId] || {};
         const dayShifts = weekSchedule[dayIndex] || [];
         return dayShifts.find((shift) => shift.employeeId === employeeId) || null;
+    },
+
+    syncMonthlyEditorMethodUI() {
+        const method = this.monthlyTimeMethod === 'end' ? 'end' : 'duration';
+        const durationWrap = el("#monthly-editor-duration-wrap");
+        const endWrap = el("#monthly-editor-end-wrap");
+        if (durationWrap) durationWrap.style.display = method === 'duration' ? 'flex' : 'none';
+        if (endWrap) endWrap.style.display = method === 'end' ? 'flex' : 'none';
     },
 
     calendarDate: new Date(),
@@ -1261,14 +1273,24 @@ export const ScheduleManager = {
         const roleSelect = el("#monthly-editor-role");
         const startSelect = el("#monthly-editor-start");
         const durationSelect = el("#monthly-editor-duration");
-        if (!roleSelect || !startSelect || !durationSelect) return;
+        const endSelect = el("#monthly-editor-end");
+        const methodSelect = el("#monthly-editor-method");
+        if (!roleSelect || !startSelect || !durationSelect || !endSelect || !methodSelect) return;
 
         this.optionize(roleSelect, [{ key: '' }, ...this.getRoleList()], (role) => ({ value: role.key, label: role.key || 'OFF' }));
         this.optionize(startSelect, [{ label: '', index: '' }, ...SLOTS], (slot) => ({ value: slot.index, label: slot.label || '--' }));
+        this.optionize(endSelect, [{ index: '' }, ...SLOTS], (slot) => {
+            if (slot.index === '') return { value: '', label: '--' };
+            const endLabel = SLOTS[Number(slot.index) + 1]?.label || SLOTS[Number(slot.index)]?.label || '';
+            return { value: slot.index, label: endLabel };
+        });
         const shift = this.getEmployeeShiftForDate(employee.id, date);
         roleSelect.value = shift?.role || '';
         startSelect.value = shift ? String(shift.startSlot) : '';
         durationSelect.value = shift ? String((shift.endSlot - shift.startSlot + 1) / 2) : '';
+        endSelect.value = shift ? String(shift.endSlot) : '';
+        methodSelect.value = this.monthlyTimeMethod === 'end' ? 'end' : 'duration';
+        this.syncMonthlyEditorMethodUI();
 
         this.renderMonthlyPlanner();
     },
@@ -1366,20 +1388,32 @@ export const ScheduleManager = {
         if (!context) return;
         const role = el("#monthly-editor-role")?.value || '';
         const startSlot = Number(el("#monthly-editor-start")?.value);
+        const method = el("#monthly-editor-method")?.value === 'end' ? 'end' : 'duration';
+        this.monthlyTimeMethod = method;
         const durationHours = Number(el("#monthly-editor-duration")?.value);
         const durationSlots = Math.round(durationHours * 2);
-        const endSlot = startSlot + durationSlots - 1;
+        const endSlotByDuration = startSlot + durationSlots - 1;
+        const endSlotManual = Number(el("#monthly-editor-end")?.value);
+        const endSlot = method === 'end' ? endSlotManual : endSlotByDuration;
 
         if (!role) {
             showToast("Seleccioná un puesto o usá 'Marcar OFF'.", "warning");
             return;
         }
-        if (!Number.isFinite(startSlot) || !Number.isFinite(durationHours) || durationHours <= 0) {
-            showToast("Definí una hora de inicio y duración válidas.", "warning");
+        if (!Number.isFinite(startSlot)) {
+            showToast("Definí una hora de inicio válida.", "warning");
+            return;
+        }
+        if (method === 'duration' && (!Number.isFinite(durationHours) || durationHours <= 0)) {
+            showToast("Definí una duración válida.", "warning");
+            return;
+        }
+        if (method === 'end' && (!Number.isFinite(endSlotManual) || endSlotManual < startSlot)) {
+            showToast("Definí una hora de salida válida.", "warning");
             return;
         }
         if (!Number.isFinite(endSlot) || endSlot >= SLOTS.length) {
-            showToast("La duración seleccionada supera el horario permitido.", "warning");
+            showToast("El turno calculado supera el horario permitido.", "warning");
             return;
         }
 

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -461,6 +461,7 @@ export const ScheduleManager = {
         const btnPrev = el("#btn-prev-week");
         const btnNext = el("#btn-next-week");
         const weekDisplay = el("#week-display");
+        const summaryBtn = el("#btn-weekly-summary");
 
         if (monthlySection) monthlySection.style.display = isMonthlyMode ? "flex" : "none";
         if (scroller) scroller.style.display = isMonthlyMode ? "none" : "block";
@@ -476,6 +477,7 @@ export const ScheduleManager = {
         if (btnPrev) btnPrev.style.display = isMonthlyMode ? "none" : "inline-flex";
         if (btnNext) btnNext.style.display = isMonthlyMode ? "none" : "inline-flex";
         if (weekDisplay) weekDisplay.style.display = isMonthlyMode ? "none" : "inline-flex";
+        if (summaryBtn) summaryBtn.textContent = isMonthlyMode ? "Resumen mensual" : "Resumen semanal";
     },
 
     // --- Template Logic ---

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1131,34 +1131,41 @@ export const ScheduleManager = {
         const formatDate = (d) => `${String(d.getDate()).padStart(2,'0')}/${String(d.getMonth()+1).padStart(2,'0')}/${d.getFullYear()}`;
         const storeLabel = this.escapeHtml(this.getActiveStoreLabel());
 
-        let tableRows = '';
-        employees.forEach(emp => {
-            let row = `<tr><td>${this.escapeHtml(emp.name)}</td>`;
-            for (let dayOffset = 0; dayOffset < periodDays; dayOffset++) {
-                const dayShifts = this.getShiftsByDayOffset(dayOffset).filter(s => s.employeeId === emp.id);
-                if (dayShifts.length > 0) {
-                    const shift = dayShifts[0];
-                    const startTime = SLOTS[shift.startSlot].label;
-                    const endTime = SLOTS[shift.endSlot + 1] ? SLOTS[shift.endSlot + 1].label : "02:00";
-                    row += `<td>${startTime} - ${endTime}</td>`;
-                } else {
-                    row += `<td>Descanso</td>`;
-                }
+        const chunkSize = periodDays > 10 ? 7 : periodDays;
+        const sections = [];
+        for (let startOffset = 0; startOffset < periodDays; startOffset += chunkSize) {
+            const endOffset = Math.min(startOffset + chunkSize, periodDays);
+            const dayHeaders = [];
+            for (let dayOffset = startOffset; dayOffset < endOffset; dayOffset++) {
+                const dayDate = new Date(monday);
+                dayDate.setDate(monday.getDate() + dayOffset);
+                const dayName = dayDate.toLocaleDateString('es-AR', { weekday: 'short' }).replace('.', '');
+                dayHeaders.push(`<th>${this.escapeHtml(dayName)}<br>${dayDate.getDate()}/${dayDate.getMonth() + 1}</th>`);
             }
-            row += '</tr>';
-            tableRows += row;
-        });
 
-        const dayHeaders = [];
-        for (let dayOffset = 0; dayOffset < periodDays; dayOffset++) {
-            const dayDate = new Date(monday);
-            dayDate.setDate(monday.getDate() + dayOffset);
-            const dayName = dayDate.toLocaleDateString('es-AR', { weekday: 'short' }).replace('.', '');
-            dayHeaders.push(`<th>${this.escapeHtml(dayName)}<br>${dayDate.getDate()}/${dayDate.getMonth() + 1}</th>`);
+            let tableRows = '';
+            employees.forEach(emp => {
+                let row = `<tr><td>${this.escapeHtml(emp.name)}</td>`;
+                for (let dayOffset = startOffset; dayOffset < endOffset; dayOffset++) {
+                    const dayShifts = this.getShiftsByDayOffset(dayOffset).filter(s => s.employeeId === emp.id);
+                    if (dayShifts.length > 0) {
+                        const shift = dayShifts[0];
+                        const startTime = SLOTS[shift.startSlot].label;
+                        const endTime = SLOTS[shift.endSlot + 1] ? SLOTS[shift.endSlot + 1].label : "02:00";
+                        row += `<td>${startTime}<br>${endTime}</td>`;
+                    } else {
+                        row += `<td>OFF</td>`;
+                    }
+                }
+                row += '</tr>';
+                tableRows += row;
+            });
+
+            sections.push(`<section class="print-section"><h3>Días ${startOffset + 1} al ${endOffset}</h3><table><thead><tr><th>Nombre</th>${dayHeaders.join('')}</tr></thead><tbody>${tableRows}</tbody></table></section>`);
         }
 
         const w = window.open('', '', 'height=800,width=1200');
-        w.document.write(`<html><head><title>Horarios</title><style>body{font-family:sans-serif;font-size:10px}table{width:100%;border-collapse:collapse}th,td{border:1px solid #ccc;padding:5px;text-align:center}th{background:#f2f2f2}@media print{body{margin:0.5in}}</style></head><body><h2>${storeLabel} - Período ${formatDate(monday)} al ${formatDate(periodEnd)}</h2><table><thead><tr><th>Nombre</th>${dayHeaders.join('')}</tr></thead><tbody>${tableRows}</tbody></table><script>setTimeout(()=>{window.print();window.close()},500)</script></body></html>`);
+        w.document.write(`<html><head><title>Horarios</title><style>body{font-family:sans-serif;font-size:9px}h3{margin:8px 0}table{width:100%;border-collapse:collapse;table-layout:fixed}th,td{border:1px solid #ccc;padding:4px;text-align:center;word-wrap:break-word}th{background:#f2f2f2}.print-section{margin-bottom:14px}@media print{@page{size:landscape;margin:8mm}.print-section{page-break-after:always}.print-section:last-child{page-break-after:auto}}</style></head><body><h2>${storeLabel} - Período ${formatDate(monday)} al ${formatDate(periodEnd)}</h2>${sections.join('')}<script>setTimeout(()=>{window.print();window.close()},500)</script></body></html>`);
         w.document.close();
     },
 

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -36,8 +36,8 @@ export const ScheduleManager = {
         el("#btnUndo")?.addEventListener("click", () => this.undoLastAction());
 
         el("#weekSelector")?.addEventListener("change", (e) => this.changeWeek(e.target.value));
-        el("#btn-prev-week")?.addEventListener("click", () => this.changeWeek(-7));
-        el("#btn-next-week")?.addEventListener("click", () => this.changeWeek(7));
+        el("#btn-prev-week")?.addEventListener("click", () => this.changeWeek(-this.getSchedulingPeriodDays()));
+        el("#btn-next-week")?.addEventListener("click", () => this.changeWeek(this.getSchedulingPeriodDays()));
         el("#btn-lock-week")?.addEventListener("click", () => this.toggleWeekLock());
 
         // Filters dropdown toggle
@@ -193,6 +193,46 @@ export const ScheduleManager = {
         return roles && roles.length ? roles : ROLES;
     },
 
+    getSchedulingPeriodWeeks() {
+        const value = Number(store.getState().schedulingPeriodWeeks);
+        return [1, 2, 4].includes(value) ? value : 1;
+    },
+
+    getSchedulingPeriodDays() {
+        return this.getSchedulingPeriodWeeks() * 7;
+    },
+
+    getWeekIdByDayOffset(dayOffset) {
+        const baseDate = new Date(`${store.getState().activeWeek}T12:00:00.000Z`);
+        baseDate.setUTCDate(baseDate.getUTCDate() + dayOffset);
+        return toISODateString(getMonday(baseDate));
+    },
+
+    getDayIndexByOffset(dayOffset) {
+        const normalized = ((dayOffset % 7) + 7) % 7;
+        return normalized;
+    },
+
+    getShiftsByDayOffset(dayOffset) {
+        const state = store.getState();
+        const weekId = this.getWeekIdByDayOffset(dayOffset);
+        const dayIndex = this.getDayIndexByOffset(dayOffset);
+        const weekSchedule = state.schedules[weekId] || {};
+        return Array.isArray(weekSchedule[dayIndex]) ? weekSchedule[dayIndex] : [];
+    },
+
+    async preloadPeriodWeeks() {
+        const weeks = this.getSchedulingPeriodWeeks();
+        const promises = [];
+        for (let i = 1; i < weeks; i++) {
+            const weekId = this.getWeekIdByDayOffset(i * 7);
+            if (!store.getState().schedules[weekId]) {
+                promises.push(DataManager.getWeekData(weekId));
+            }
+        }
+        if (promises.length) await Promise.all(promises);
+    },
+
     calendarDate: new Date(),
 
     renderCalendar() {
@@ -301,6 +341,7 @@ export const ScheduleManager = {
 
     render() {
         this.hideEmployeeWeekTooltip();
+        this.preloadPeriodWeeks().catch((error) => console.warn('No se pudieron precargar semanas del período.', error));
         const roles = this.getRoleList();
         const activeRoleSelect = el("#activeRole");
         const filterSelect = el("#schedule-role-filter");
@@ -1000,23 +1041,28 @@ export const ScheduleManager = {
     },
 
     printSchedule() {
-        const schedule = getActiveSchedule();
         const state = store.getState();
+        const periodDays = this.getSchedulingPeriodDays();
         const employees = state.employees
-            .filter(emp => this.getEmployeeWeeklyHours(emp.id) > 0)
+            .filter(emp => {
+                for (let dayOffset = 0; dayOffset < periodDays; dayOffset++) {
+                    if (this.getShiftsByDayOffset(dayOffset).some(s => s.employeeId === emp.id)) return true;
+                }
+                return false;
+            })
             .sort((a,b) => a.name.localeCompare(b.name));
 
         const monday = new Date(state.activeWeek + "T12:00:00Z");
-        const sunday = new Date(monday);
-        sunday.setDate(monday.getDate() + 6);
+        const periodEnd = new Date(monday);
+        periodEnd.setDate(monday.getDate() + periodDays - 1);
         const formatDate = (d) => `${String(d.getDate()).padStart(2,'0')}/${String(d.getMonth()+1).padStart(2,'0')}/${d.getFullYear()}`;
         const storeLabel = this.escapeHtml(this.getActiveStoreLabel());
 
         let tableRows = '';
         employees.forEach(emp => {
             let row = `<tr><td>${this.escapeHtml(emp.name)}</td>`;
-            for (let i = 0; i < 7; i++) {
-                const dayShifts = (schedule[i] || []).filter(s => s.employeeId === emp.id);
+            for (let dayOffset = 0; dayOffset < periodDays; dayOffset++) {
+                const dayShifts = this.getShiftsByDayOffset(dayOffset).filter(s => s.employeeId === emp.id);
                 if (dayShifts.length > 0) {
                     const shift = dayShifts[0];
                     const startTime = SLOTS[shift.startSlot].label;
@@ -1030,8 +1076,16 @@ export const ScheduleManager = {
             tableRows += row;
         });
 
+        const dayHeaders = [];
+        for (let dayOffset = 0; dayOffset < periodDays; dayOffset++) {
+            const dayDate = new Date(monday);
+            dayDate.setDate(monday.getDate() + dayOffset);
+            const dayName = dayDate.toLocaleDateString('es-AR', { weekday: 'short' }).replace('.', '');
+            dayHeaders.push(`<th>${this.escapeHtml(dayName)}<br>${dayDate.getDate()}/${dayDate.getMonth() + 1}</th>`);
+        }
+
         const w = window.open('', '', 'height=800,width=1200');
-        w.document.write(`<html><head><title>Horarios</title><style>body{font-family:sans-serif;font-size:10px}table{width:100%;border-collapse:collapse}th,td{border:1px solid #ccc;padding:5px;text-align:center}th{background:#f2f2f2}@media print{body{margin:0.5in}}</style></head><body><h2>${storeLabel} - Semana ${formatDate(monday)} al ${formatDate(sunday)}</h2><table><thead><tr><th>Nombre</th>${DAYS.map(d=>`<th>${d}</th>`).join('')}</tr></thead><tbody>${tableRows}</tbody></table><script>setTimeout(()=>{window.print();window.close()},500)</script></body></html>`);
+        w.document.write(`<html><head><title>Horarios</title><style>body{font-family:sans-serif;font-size:10px}table{width:100%;border-collapse:collapse}th,td{border:1px solid #ccc;padding:5px;text-align:center}th{background:#f2f2f2}@media print{body{margin:0.5in}}</style></head><body><h2>${storeLabel} - Período ${formatDate(monday)} al ${formatDate(periodEnd)}</h2><table><thead><tr><th>Nombre</th>${dayHeaders.join('')}</tr></thead><tbody>${tableRows}</tbody></table><script>setTimeout(()=>{window.print();window.close()},500)</script></body></html>`);
         w.document.close();
     },
 
@@ -1777,11 +1831,11 @@ export const ScheduleManager = {
         if (!btn) return;
         const state = store.getState();
         const monday = new Date(state.activeWeek + "T12:00:00Z");
-        const sunday = new Date(monday);
-        sunday.setDate(monday.getDate() + 6);
+        const periodEnd = new Date(monday);
+        periodEnd.setDate(monday.getDate() + this.getSchedulingPeriodDays() - 1);
 
         const format = (d) => `${d.getDate()}/${d.getMonth()+1}`;
-        btn.textContent = `${format(monday)} - ${format(sunday)}`;
+        btn.textContent = `${format(monday)} - ${format(periodEnd)}`;
 
         this.ensureSavingIndicator();
         this.setSavingStatus(false);
@@ -1796,11 +1850,17 @@ export const ScheduleManager = {
         let totalHours = 0;
         let totalTickets = 0;
 
-        const weekTickets = state.projectedTickets[state.activeWeek] || {};
-
-        for (let i = 0; i < 7; i++) {
-            totalHours += this.calculateTotalDayHours(i);
-            totalTickets += Number(weekTickets[i] || 0);
+        const periodDays = this.getSchedulingPeriodDays();
+        for (let dayOffset = 0; dayOffset < periodDays; dayOffset++) {
+            const weekId = this.getWeekIdByDayOffset(dayOffset);
+            const dayIndex = this.getDayIndexByOffset(dayOffset);
+            const weekData = state.schedules[weekId] || {};
+            const dayShifts = weekData[dayIndex] || [];
+            dayShifts.forEach(shift => {
+                totalHours += (shift.endSlot - shift.startSlot + 1) / 2;
+            });
+            const weekTickets = state.projectedTickets[weekId] || {};
+            totalTickets += Number(weekTickets[dayIndex] || 0);
         }
 
         const productivity = totalHours > 0 ? (totalTickets / totalHours).toFixed(1) : "-";

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -186,6 +186,12 @@ export const ScheduleManager = {
 
         // Templates
         el("#btnSaveTemplate")?.addEventListener("click", () => this.saveCurrentDayAsTemplate());
+        el("#monthly-planner-month")?.addEventListener("change", (e) => {
+            this.monthlySelectedMonth = e.target.value;
+            this.renderMonthlyPlanner();
+        });
+        el("#monthly-editor-save")?.addEventListener("click", () => this.saveMonthlyEditorCell());
+        el("#monthly-editor-clear")?.addEventListener("click", () => this.clearMonthlyEditorCell());
     },
 
     getRoleList() {
@@ -231,6 +237,46 @@ export const ScheduleManager = {
             }
         }
         if (promises.length) await Promise.all(promises);
+    },
+
+    getMonthlySelectedMonth() {
+        if (this.monthlySelectedMonth) return this.monthlySelectedMonth;
+        const today = new Date();
+        const month = String(today.getMonth() + 1).padStart(2, '0');
+        this.monthlySelectedMonth = `${today.getFullYear()}-${month}`;
+        return this.monthlySelectedMonth;
+    },
+
+    getDatesForNaturalMonth(monthValue) {
+        const [year, month] = (monthValue || '').split('-').map(Number);
+        if (!year || !month) return [];
+        const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+        return Array.from({ length: lastDay }, (_, idx) => new Date(Date.UTC(year, month - 1, idx + 1, 12, 0, 0)));
+    },
+
+    async preloadMonthWeeks(monthValue) {
+        const dates = this.getDatesForNaturalMonth(monthValue);
+        const uniqueWeeks = new Set(dates.map((date) => toISODateString(getMonday(date))));
+        const promises = [];
+        uniqueWeeks.forEach((weekId) => {
+            if (!store.getState().schedules[weekId]) {
+                promises.push(DataManager.getWeekData(weekId));
+            }
+        });
+        if (promises.length) await Promise.all(promises);
+    },
+
+    getWeekAndDayFromDate(date) {
+        const weekId = toISODateString(getMonday(date));
+        const dayIndex = (date.getUTCDay() + 6) % 7;
+        return { weekId, dayIndex };
+    },
+
+    getEmployeeShiftForDate(employeeId, date) {
+        const { weekId, dayIndex } = this.getWeekAndDayFromDate(date);
+        const weekSchedule = store.getState().schedules[weekId] || {};
+        const dayShifts = weekSchedule[dayIndex] || [];
+        return dayShifts.find((shift) => shift.employeeId === employeeId) || null;
     },
 
     calendarDate: new Date(),
@@ -342,6 +388,7 @@ export const ScheduleManager = {
     render() {
         this.hideEmployeeWeekTooltip();
         this.preloadPeriodWeeks().catch((error) => console.warn('No se pudieron precargar semanas del período.', error));
+        this.toggleMonthlyPlannerMode();
         const roles = this.getRoleList();
         const activeRoleSelect = el("#activeRole");
         const filterSelect = el("#schedule-role-filter");
@@ -375,6 +422,27 @@ export const ScheduleManager = {
         if (store.getState().activeView === 'schedule-list') {
             this.renderScheduleList();
         }
+
+        if (this.getSchedulingPeriodWeeks() === 4) {
+            this.renderMonthlyPlanner();
+        }
+    },
+
+    toggleMonthlyPlannerMode() {
+        const isMonthlyMode = this.getSchedulingPeriodWeeks() === 4;
+        const monthlySection = el("#monthly-planner-section");
+        const scroller = document.querySelector("#view-schedule .scroller");
+        const dayTabs = el("#dayTabs");
+        const dayTitle = el("#day-title");
+        const projectedTickets = el("#projectedTickets");
+        const suggestBtn = el("#btn-suggest-productivity");
+
+        if (monthlySection) monthlySection.style.display = isMonthlyMode ? "flex" : "none";
+        if (scroller) scroller.style.display = isMonthlyMode ? "none" : "block";
+        if (dayTabs) dayTabs.style.display = isMonthlyMode ? "none" : "flex";
+        if (dayTitle) dayTitle.style.display = isMonthlyMode ? "none" : "block";
+        if (projectedTickets) projectedTickets.disabled = isMonthlyMode;
+        if (suggestBtn) suggestBtn.style.display = isMonthlyMode ? "none" : "inline-flex";
     },
 
     // --- Template Logic ---
@@ -1087,6 +1155,173 @@ export const ScheduleManager = {
         const w = window.open('', '', 'height=800,width=1200');
         w.document.write(`<html><head><title>Horarios</title><style>body{font-family:sans-serif;font-size:10px}table{width:100%;border-collapse:collapse}th,td{border:1px solid #ccc;padding:5px;text-align:center}th{background:#f2f2f2}@media print{body{margin:0.5in}}</style></head><body><h2>${storeLabel} - Período ${formatDate(monday)} al ${formatDate(periodEnd)}</h2><table><thead><tr><th>Nombre</th>${dayHeaders.join('')}</tr></thead><tbody>${tableRows}</tbody></table><script>setTimeout(()=>{window.print();window.close()},500)</script></body></html>`);
         w.document.close();
+    },
+
+    async renderMonthlyPlanner() {
+        if (this.getSchedulingPeriodWeeks() !== 4) return;
+        const monthInput = el("#monthly-planner-month");
+        const gridContainer = el("#monthly-planner-grid");
+        const editor = el("#monthly-planner-editor");
+        const targetBadge = el("#monthly-editor-target");
+        if (!monthInput || !gridContainer || !editor || !targetBadge) return;
+
+        const monthValue = this.getMonthlySelectedMonth();
+        if (monthInput.value !== monthValue) monthInput.value = monthValue;
+
+        await this.preloadMonthWeeks(monthValue);
+
+        const dates = this.getDatesForNaturalMonth(monthValue);
+        const state = store.getState();
+        const employees = [...state.employees].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+        const selectedKey = this.monthlyEditorContext ? `${this.monthlyEditorContext.employeeId}|${this.monthlyEditorContext.dateISO}` : null;
+
+        clear(gridContainer);
+        const table = create("table", { className: "monthly-grid-table" });
+        const thead = create("thead");
+        const headerRow = create("tr");
+        headerRow.appendChild(create("th", { className: "monthly-employee-cell", textContent: "APELLIDO Y NOMBRE" }));
+        dates.forEach((date) => {
+            const dayName = date.toLocaleDateString('es-AR', { weekday: 'short', timeZone: 'UTC' }).replace('.', '').toUpperCase();
+            headerRow.appendChild(create("th", { innerHTML: `${dayName}<br>${String(date.getUTCDate()).padStart(2, '0')}` }));
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        const tbody = create("tbody");
+        employees.forEach((employee) => {
+            const row = create("tr");
+            row.appendChild(create("td", { className: "monthly-employee-cell", textContent: employee.name || employee.displayName || 'Sin nombre' }));
+
+            dates.forEach((date) => {
+                const dateISO = toISODateString(date);
+                const shift = this.getEmployeeShiftForDate(employee.id, date);
+                const roleInfo = shift ? this.getRoleList().find((role) => role.key === shift.role) : null;
+                const { weekId } = this.getWeekAndDayFromDate(date);
+                const isLocked = !!(store.getState().schedules[weekId]?.isLocked);
+                const cellKey = `${employee.id}|${dateISO}`;
+
+                const cell = create("td", {
+                    className: `monthly-shift-cell ${shift ? 'active' : 'off'}${selectedKey === cellKey ? ' selected' : ''}`,
+                    title: isLocked ? 'La semana de esta fecha está bloqueada' : 'Click para editar',
+                });
+                if (roleInfo) {
+                    cell.style.background = roleInfo.color;
+                    cell.style.color = roleInfo.darkText ? '#111' : '#fff';
+                }
+
+                if (shift) {
+                    const startLabel = SLOTS[shift.startSlot]?.label || '';
+                    const endLabel = SLOTS[shift.endSlot + 1]?.label || '';
+                    cell.innerHTML = `<div>${startLabel}</div><div>${endLabel}</div><div style="font-size:10px;">${this.escapeHtml(shift.role || '')}</div>`;
+                } else {
+                    cell.textContent = 'OFF';
+                }
+
+                if (!isLocked) {
+                    cell.addEventListener('click', () => this.selectMonthlyCell(employee, date));
+                }
+
+                row.appendChild(cell);
+            });
+
+            tbody.appendChild(row);
+        });
+
+        table.appendChild(tbody);
+        gridContainer.appendChild(table);
+
+        if (this.monthlyEditorContext) {
+            const selectedEmployee = state.employees.find((emp) => emp.id === this.monthlyEditorContext.employeeId);
+            const selectedDate = new Date(`${this.monthlyEditorContext.dateISO}T12:00:00.000Z`);
+            targetBadge.textContent = `${selectedEmployee?.name || 'Empleado'} · ${selectedDate.toLocaleDateString('es-AR', { timeZone: 'UTC' })}`;
+            editor.style.display = "flex";
+        } else {
+            editor.style.display = "none";
+        }
+    },
+
+    selectMonthlyCell(employee, date) {
+        const dateISO = toISODateString(date);
+        this.monthlyEditorContext = { employeeId: employee.id, dateISO };
+
+        const roleSelect = el("#monthly-editor-role");
+        const startSelect = el("#monthly-editor-start");
+        const endSelect = el("#monthly-editor-end");
+        if (!roleSelect || !startSelect || !endSelect) return;
+
+        this.optionize(roleSelect, [{ key: '' }, ...this.getRoleList()], (role) => ({ value: role.key, label: role.key || 'OFF' }));
+        this.optionize(startSelect, [{ label: '', index: '' }, ...SLOTS], (slot) => ({ value: slot.index, label: slot.label || '--' }));
+        this.optionize(endSelect, [{ index: '' }, ...SLOTS], (slot) => {
+            if (slot.index === '') return { value: '', label: '--' };
+            const endLabel = SLOTS[Number(slot.index) + 1]?.label || SLOTS[Number(slot.index)]?.label || '';
+            return { value: slot.index, label: endLabel };
+        });
+
+        const shift = this.getEmployeeShiftForDate(employee.id, date);
+        roleSelect.value = shift?.role || '';
+        startSelect.value = shift ? String(shift.startSlot) : '';
+        endSelect.value = shift ? String(shift.endSlot) : '';
+
+        this.renderMonthlyPlanner();
+    },
+
+    async saveMonthlyEditorCell() {
+        const context = this.monthlyEditorContext;
+        if (!context) return;
+        const role = el("#monthly-editor-role")?.value || '';
+        const startSlot = Number(el("#monthly-editor-start")?.value);
+        const endSlot = Number(el("#monthly-editor-end")?.value);
+
+        if (!role) {
+            showToast("Seleccioná un puesto o usá 'Marcar OFF'.", "warning");
+            return;
+        }
+        if (!Number.isFinite(startSlot) || !Number.isFinite(endSlot) || endSlot < startSlot) {
+            showToast("Definí una entrada y salida válidas.", "warning");
+            return;
+        }
+
+        const date = new Date(`${context.dateISO}T12:00:00.000Z`);
+        const { weekId, dayIndex } = this.getWeekAndDayFromDate(date);
+        await DataManager.getWeekData(weekId);
+        const currentState = store.getState();
+        const schedules = { ...currentState.schedules };
+        const weekSchedule = { ...(schedules[weekId] || {}) };
+        const dayShifts = [...(weekSchedule[dayIndex] || [])];
+
+        const remainingShifts = dayShifts.filter((shift) => shift.employeeId !== context.employeeId);
+        remainingShifts.push({
+            id: crypto.randomUUID(),
+            employeeId: context.employeeId,
+            role,
+            startSlot,
+            endSlot,
+            ignoreRestrictions: false,
+        });
+        weekSchedule[dayIndex] = remainingShifts;
+        schedules[weekId] = weekSchedule;
+        store.setState({ schedules });
+        await DataManager.saveWeek(weekId);
+        showToast("Turno mensual guardado.", "success");
+        this.renderMonthlyPlanner();
+    },
+
+    async clearMonthlyEditorCell() {
+        const context = this.monthlyEditorContext;
+        if (!context) return;
+        const date = new Date(`${context.dateISO}T12:00:00.000Z`);
+        const { weekId, dayIndex } = this.getWeekAndDayFromDate(date);
+        await DataManager.getWeekData(weekId);
+        const currentState = store.getState();
+        const schedules = { ...currentState.schedules };
+        const weekSchedule = { ...(schedules[weekId] || {}) };
+        const dayShifts = [...(weekSchedule[dayIndex] || [])];
+        weekSchedule[dayIndex] = dayShifts.filter((shift) => shift.employeeId !== context.employeeId);
+        schedules[weekId] = weekSchedule;
+        store.setState({ schedules });
+        await DataManager.saveWeek(weekId);
+        showToast("Celda marcada como OFF.", "success");
+        this.renderMonthlyPlanner();
     },
 
     printDailyPlanning() {

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -192,6 +192,11 @@ export const ScheduleManager = {
         });
         el("#monthly-editor-save")?.addEventListener("click", () => this.saveMonthlyEditorCell());
         el("#monthly-editor-clear")?.addEventListener("click", () => this.clearMonthlyEditorCell());
+        document.addEventListener("keydown", (e) => this.handleMonthlyKeyboardShortcuts(e));
+        document.addEventListener("click", (e) => {
+            const menu = document.querySelector('.monthly-context-menu');
+            if (menu && !menu.contains(e.target)) menu.remove();
+        });
     },
 
     getRoleList() {
@@ -1203,6 +1208,7 @@ export const ScheduleManager = {
                 const cell = create("td", {
                     className: `monthly-shift-cell ${shift ? 'active' : 'off'}${selectedKey === cellKey ? ' selected' : ''}`,
                     title: isLocked ? 'La semana de esta fecha está bloqueada' : 'Click para editar',
+                    dataset: { employeeId: employee.id, dateIso: dateISO }
                 });
                 if (roleInfo) {
                     cell.style.background = roleInfo.color;
@@ -1219,6 +1225,7 @@ export const ScheduleManager = {
 
                 if (!isLocked) {
                     cell.addEventListener('click', () => this.selectMonthlyCell(employee, date));
+                    cell.addEventListener('contextmenu', (event) => this.openMonthlyContextMenu(event, employee, date));
                 }
 
                 row.appendChild(cell);
@@ -1265,6 +1272,94 @@ export const ScheduleManager = {
         this.renderMonthlyPlanner();
     },
 
+    openMonthlyContextMenu(event, employee, date) {
+        event.preventDefault();
+        this.selectMonthlyCell(employee, date);
+
+        const existing = document.querySelector('.monthly-context-menu');
+        if (existing) existing.remove();
+
+        const menu = create("div", { className: "monthly-context-menu" });
+        menu.appendChild(create("button", {
+            textContent: "Copiar turno",
+            onClick: () => {
+                this.copySelectedMonthlyCell();
+                menu.remove();
+            }
+        }));
+        menu.appendChild(create("button", {
+            textContent: "Pegar turno",
+            onClick: () => {
+                this.pasteToSelectedMonthlyCell();
+                menu.remove();
+            }
+        }));
+        document.body.appendChild(menu);
+        menu.style.left = `${event.clientX}px`;
+        menu.style.top = `${event.clientY}px`;
+    },
+
+    handleMonthlyKeyboardShortcuts(event) {
+        if (this.getSchedulingPeriodWeeks() !== 4 || !this.monthlyEditorContext) return;
+        const activeTag = document.activeElement?.tagName;
+        if (activeTag === 'INPUT' || activeTag === 'TEXTAREA') return;
+        const isCopy = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c';
+        const isPaste = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'v';
+        if (isCopy) {
+            event.preventDefault();
+            this.copySelectedMonthlyCell();
+        }
+        if (isPaste) {
+            event.preventDefault();
+            this.pasteToSelectedMonthlyCell();
+        }
+    },
+
+    copySelectedMonthlyCell() {
+        const context = this.monthlyEditorContext;
+        if (!context) return;
+        const date = new Date(`${context.dateISO}T12:00:00.000Z`);
+        const shift = this.getEmployeeShiftForDate(context.employeeId, date);
+        this.monthlyClipboard = shift
+            ? { role: shift.role, startSlot: shift.startSlot, endSlot: shift.endSlot }
+            : null;
+        showToast(shift ? "Turno copiado." : "Se copió una celda OFF.", "info");
+    },
+
+    async pasteToSelectedMonthlyCell() {
+        if (!this.monthlyEditorContext || this.monthlyClipboard === undefined) return;
+        await this.applyMonthlyCellData(this.monthlyEditorContext, this.monthlyClipboard);
+        showToast("Turno pegado.", "success");
+    },
+
+    async applyMonthlyCellData(context, shiftData) {
+        const date = new Date(`${context.dateISO}T12:00:00.000Z`);
+        const { weekId, dayIndex } = this.getWeekAndDayFromDate(date);
+        await DataManager.getWeekData(weekId);
+        const currentState = store.getState();
+        const schedules = { ...currentState.schedules };
+        const weekSchedule = { ...(schedules[weekId] || {}) };
+        const dayShifts = [...(weekSchedule[dayIndex] || [])];
+        const remainingShifts = dayShifts.filter((shift) => shift.employeeId !== context.employeeId);
+
+        if (shiftData) {
+            remainingShifts.push({
+                id: crypto.randomUUID(),
+                employeeId: context.employeeId,
+                role: shiftData.role,
+                startSlot: shiftData.startSlot,
+                endSlot: shiftData.endSlot,
+                ignoreRestrictions: false,
+            });
+        }
+
+        weekSchedule[dayIndex] = remainingShifts;
+        schedules[weekId] = weekSchedule;
+        store.setState({ schedules });
+        await DataManager.saveWeek(weekId);
+        this.renderMonthlyPlanner();
+    },
+
     async saveMonthlyEditorCell() {
         const context = this.monthlyEditorContext;
         if (!context) return;
@@ -1281,47 +1376,19 @@ export const ScheduleManager = {
             return;
         }
 
-        const date = new Date(`${context.dateISO}T12:00:00.000Z`);
-        const { weekId, dayIndex } = this.getWeekAndDayFromDate(date);
-        await DataManager.getWeekData(weekId);
-        const currentState = store.getState();
-        const schedules = { ...currentState.schedules };
-        const weekSchedule = { ...(schedules[weekId] || {}) };
-        const dayShifts = [...(weekSchedule[dayIndex] || [])];
-
-        const remainingShifts = dayShifts.filter((shift) => shift.employeeId !== context.employeeId);
-        remainingShifts.push({
-            id: crypto.randomUUID(),
-            employeeId: context.employeeId,
+        await this.applyMonthlyCellData(context, {
             role,
             startSlot,
             endSlot,
-            ignoreRestrictions: false,
         });
-        weekSchedule[dayIndex] = remainingShifts;
-        schedules[weekId] = weekSchedule;
-        store.setState({ schedules });
-        await DataManager.saveWeek(weekId);
         showToast("Turno mensual guardado.", "success");
-        this.renderMonthlyPlanner();
     },
 
     async clearMonthlyEditorCell() {
         const context = this.monthlyEditorContext;
         if (!context) return;
-        const date = new Date(`${context.dateISO}T12:00:00.000Z`);
-        const { weekId, dayIndex } = this.getWeekAndDayFromDate(date);
-        await DataManager.getWeekData(weekId);
-        const currentState = store.getState();
-        const schedules = { ...currentState.schedules };
-        const weekSchedule = { ...(schedules[weekId] || {}) };
-        const dayShifts = [...(weekSchedule[dayIndex] || [])];
-        weekSchedule[dayIndex] = dayShifts.filter((shift) => shift.employeeId !== context.employeeId);
-        schedules[weekId] = weekSchedule;
-        store.setState({ schedules });
-        await DataManager.saveWeek(weekId);
+        await this.applyMonthlyCellData(context, null);
         showToast("Celda marcada como OFF.", "success");
-        this.renderMonthlyPlanner();
     },
 
     printDailyPlanning() {

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1367,14 +1367,24 @@ export const ScheduleManager = {
 
     async pasteToSelectedMonthlyCell() {
         if (!this.monthlyEditorContext || this.monthlyClipboard === undefined) return;
-        await this.applyMonthlyCellData(this.monthlyEditorContext, this.monthlyClipboard);
-        showToast("Turno pegado.", "success");
+        const saved = await this.applyMonthlyCellData(this.monthlyEditorContext, this.monthlyClipboard);
+        if (saved) showToast("Turno pegado.", "success");
     },
 
     async applyMonthlyCellData(context, shiftData) {
         const date = new Date(`${context.dateISO}T12:00:00.000Z`);
         const { weekId, dayIndex } = this.getWeekAndDayFromDate(date);
         await DataManager.getWeekData(weekId);
+        if (shiftData) {
+            const warnings = this.getMonthlyShiftWarnings(context, shiftData, weekId, dayIndex);
+            if (warnings.length) {
+                const confirmed = await showConfirmDialog({
+                    title: "Advertencias de validación",
+                    message: `Se detectaron estas advertencias:<br><br>${warnings.map((w) => `• ${w}`).join('<br>')}<br><br>¿Guardar igualmente el turno?`
+                });
+                if (!confirmed) return false;
+            }
+        }
         const currentState = store.getState();
         const schedules = { ...currentState.schedules };
         const weekSchedule = { ...(schedules[weekId] || {}) };
@@ -1397,6 +1407,45 @@ export const ScheduleManager = {
         store.setState({ schedules });
         await DataManager.saveWeek(weekId);
         this.renderMonthlyPlanner();
+        return true;
+    },
+
+    getMonthlyShiftWarnings(context, shiftData, weekId, dayIndex) {
+        const warnings = [];
+        const state = store.getState();
+        const employee = state.employees.find((emp) => emp.id === context.employeeId);
+        if (!employee) return ["Empleado no encontrado."];
+        const rules = getSchedulingRules();
+        const shift = {
+            employeeId: context.employeeId,
+            role: shiftData.role,
+            startSlot: shiftData.startSlot,
+            endSlot: shiftData.endSlot,
+            ignoreRestrictions: false
+        };
+
+        if (rules.enforceAvailability) {
+            const availabilityCheck = checkEmployeeAvailability(employee, shift, weekId, dayIndex);
+            if (!availabilityCheck.isAvailable) warnings.push(availabilityCheck.reason);
+        }
+
+        if (rules.enforceRestTime) {
+            const restCheck = checkRestTime(employee.id, shift, weekId, dayIndex, rules.minRestHours);
+            if (!restCheck.pass) warnings.push(restCheck.message);
+        }
+
+        if (rules.maxConsecutiveDays?.enabled) {
+            const weekSchedule = state.schedules[weekId] || {};
+            const originalDay = [...(weekSchedule[dayIndex] || [])];
+            weekSchedule[dayIndex] = originalDay.filter((s) => s.employeeId !== context.employeeId).concat([{ ...shift }]);
+            const consecutiveDays = calculateConsecutiveWorkDays(employee.id, weekId, dayIndex);
+            weekSchedule[dayIndex] = originalDay;
+            if (consecutiveDays > (rules.maxConsecutiveDays.limit || 5)) {
+                warnings.push(`${employee.name} quedaría con ${consecutiveDays} días seguidos (límite ${rules.maxConsecutiveDays.limit}).`);
+            }
+        }
+
+        return warnings;
     },
 
     async saveMonthlyEditorCell() {
@@ -1433,19 +1482,19 @@ export const ScheduleManager = {
             return;
         }
 
-        await this.applyMonthlyCellData(context, {
+        const saved = await this.applyMonthlyCellData(context, {
             role,
             startSlot,
             endSlot,
         });
-        showToast("Turno mensual guardado.", "success");
+        if (saved) showToast("Turno mensual guardado.", "success");
     },
 
     async clearMonthlyEditorCell() {
         const context = this.monthlyEditorContext;
         if (!context) return;
-        await this.applyMonthlyCellData(context, null);
-        showToast("Celda marcada como OFF.", "success");
+        const saved = await this.applyMonthlyCellData(context, null);
+        if (saved) showToast("Celda marcada como OFF.", "success");
     },
 
     printDailyPlanning() {

--- a/src/modules/ScheduleManager.js
+++ b/src/modules/ScheduleManager.js
@@ -1225,7 +1225,7 @@ export const ScheduleManager = {
                 if (shift) {
                     const startLabel = SLOTS[shift.startSlot]?.label || '';
                     const endLabel = SLOTS[shift.endSlot + 1]?.label || '';
-                    cell.innerHTML = `<div>${startLabel}</div><div>${endLabel}</div><div style="font-size:10px;">${this.escapeHtml(shift.role || '')}</div>`;
+                    cell.innerHTML = `<div style="font-size:12px;font-weight:800;">${startLabel} - ${endLabel}</div><div style="font-size:9px;opacity:.9;">${this.escapeHtml(shift.role || '')}</div>`;
                 } else {
                     cell.textContent = 'OFF';
                 }
@@ -1260,21 +1260,15 @@ export const ScheduleManager = {
 
         const roleSelect = el("#monthly-editor-role");
         const startSelect = el("#monthly-editor-start");
-        const endSelect = el("#monthly-editor-end");
-        if (!roleSelect || !startSelect || !endSelect) return;
+        const durationSelect = el("#monthly-editor-duration");
+        if (!roleSelect || !startSelect || !durationSelect) return;
 
         this.optionize(roleSelect, [{ key: '' }, ...this.getRoleList()], (role) => ({ value: role.key, label: role.key || 'OFF' }));
         this.optionize(startSelect, [{ label: '', index: '' }, ...SLOTS], (slot) => ({ value: slot.index, label: slot.label || '--' }));
-        this.optionize(endSelect, [{ index: '' }, ...SLOTS], (slot) => {
-            if (slot.index === '') return { value: '', label: '--' };
-            const endLabel = SLOTS[Number(slot.index) + 1]?.label || SLOTS[Number(slot.index)]?.label || '';
-            return { value: slot.index, label: endLabel };
-        });
-
         const shift = this.getEmployeeShiftForDate(employee.id, date);
         roleSelect.value = shift?.role || '';
         startSelect.value = shift ? String(shift.startSlot) : '';
-        endSelect.value = shift ? String(shift.endSlot) : '';
+        durationSelect.value = shift ? String((shift.endSlot - shift.startSlot + 1) / 2) : '';
 
         this.renderMonthlyPlanner();
     },
@@ -1372,14 +1366,20 @@ export const ScheduleManager = {
         if (!context) return;
         const role = el("#monthly-editor-role")?.value || '';
         const startSlot = Number(el("#monthly-editor-start")?.value);
-        const endSlot = Number(el("#monthly-editor-end")?.value);
+        const durationHours = Number(el("#monthly-editor-duration")?.value);
+        const durationSlots = Math.round(durationHours * 2);
+        const endSlot = startSlot + durationSlots - 1;
 
         if (!role) {
             showToast("Seleccioná un puesto o usá 'Marcar OFF'.", "warning");
             return;
         }
-        if (!Number.isFinite(startSlot) || !Number.isFinite(endSlot) || endSlot < startSlot) {
-            showToast("Definí una entrada y salida válidas.", "warning");
+        if (!Number.isFinite(startSlot) || !Number.isFinite(durationHours) || durationHours <= 0) {
+            showToast("Definí una hora de inicio y duración válidas.", "warning");
+            return;
+        }
+        if (!Number.isFinite(endSlot) || endSlot >= SLOTS.length) {
+            showToast("La duración seleccionada supera el horario permitido.", "warning");
             return;
         }
 

--- a/src/modules/StatsManager.js
+++ b/src/modules/StatsManager.js
@@ -75,6 +75,11 @@ export const StatsManager = {
         const state = store.getState();
         const content = el("#weekly-summary-content");
         if (!content) return;
+        const isMonthlyMode = Number(state.schedulingPeriodWeeks) === 4;
+        const summaryBtn = el("#btn-weekly-summary");
+        const summaryHeading = el("#summary-modal-heading");
+        if (summaryBtn) summaryBtn.textContent = isMonthlyMode ? 'Resumen mensual' : 'Resumen semanal';
+        if (summaryHeading) summaryHeading.textContent = isMonthlyMode ? 'Resumen Mensual' : 'Resumen Semanal';
 
         const employees = state.employees.slice();
         if(employees.length === 0) {
@@ -82,20 +87,50 @@ export const StatsManager = {
             return;
         }
 
-        const getHours = (empId) => ScheduleManager.getEmployeeWeeklyHours(empId);
+        const monthValue = el("#monthly-top-month")?.value || '';
+        const monthDates = (() => {
+            if (!isMonthlyMode || !monthValue) return [];
+            const [year, month] = monthValue.split('-').map(Number);
+            if (!year || !month) return [];
+            const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+            return Array.from({ length: lastDay }, (_, idx) => new Date(Date.UTC(year, month - 1, idx + 1, 12, 0, 0)));
+        })();
+
+        const getDayShifts = (date) => {
+            const weekId = toISODateString(getMonday(date));
+            const dayIndex = (date.getUTCDay() + 6) % 7;
+            const week = state.schedules[weekId] || {};
+            return week[dayIndex] || [];
+        };
+
+        const getHours = (empId) => {
+            if (!isMonthlyMode) return ScheduleManager.getEmployeeWeeklyHours(empId);
+            return monthDates.reduce((acc, date) => {
+                const shifts = getDayShifts(date).filter(s => s.employeeId === empId);
+                return acc + shifts.reduce((sum, s) => sum + ((s.endSlot - s.startSlot + 1) / 2), 0);
+            }, 0);
+        };
 
         // Helper for working days count - assumes getActiveSchedule returns full week object
         const getWorkingDays = (empId) => {
-            const schedule = getActiveSchedule();
-            if (!schedule) return 0;
-            let days = new Set();
-            for (let i = 0; i < 7; i++) {
-                const dayShifts = schedule[i] || [];
-                if (dayShifts.some(s => s.employeeId === empId)) {
-                    days.add(i);
+            if (!isMonthlyMode) {
+                const schedule = getActiveSchedule();
+                if (!schedule) return 0;
+                let days = new Set();
+                for (let i = 0; i < 7; i++) {
+                    const dayShifts = schedule[i] || [];
+                    if (dayShifts.some(s => s.employeeId === empId)) {
+                        days.add(i);
+                    }
                 }
+                return days.size;
             }
-            return days.size;
+            const worked = new Set();
+            monthDates.forEach((date) => {
+                const dateKey = toISODateString(date);
+                if (getDayShifts(date).some(s => s.employeeId === empId)) worked.add(dateKey);
+            });
+            return worked.size;
         };
 
         const sortOrder = state.weeklySummarySort || 'alpha';
@@ -116,8 +151,10 @@ export const StatsManager = {
 
         // Helper to generate details row content
         const generateDetailsRow = (empId) => {
-            const schedule = getActiveSchedule();
-            if (!schedule) return document.createElement('div');
+            if (!isMonthlyMode) {
+                const schedule = getActiveSchedule();
+                if (!schedule) return document.createElement('div');
+            }
 
             const detailsContainer = create("div", { className: "details-container" });
             const table = create("table", { className: "details-table" });
@@ -134,9 +171,21 @@ export const StatsManager = {
             const daysMap = ['Lu', 'Ma', 'Mi', 'Ju', 'Vi', 'Sá', 'Do'];
             let hasShifts = false;
 
-            for (let i = 0; i < 7; i++) {
-                const dayShifts = (schedule[i] || []).filter(s => s.employeeId === empId);
-                dayShifts.sort((a,b) => a.startSlot - b.startSlot);
+            const iterate = isMonthlyMode
+                ? monthDates.map((date) => ({
+                    label: `${String(date.getUTCDate()).padStart(2, '0')}/${String(date.getUTCMonth() + 1).padStart(2, '0')}`,
+                    key: toISODateString(date),
+                    shifts: getDayShifts(date).filter(s => s.employeeId === empId),
+                    dayIndex: (date.getUTCDay() + 6) % 7
+                }))
+                : Array.from({ length: 7 }, (_, i) => ({
+                    label: daysMap[i],
+                    shifts: ((getActiveSchedule() || {})[i] || []).filter(s => s.employeeId === empId),
+                    dayIndex: i
+                }));
+
+            iterate.forEach((entry) => {
+                const dayShifts = entry.shifts.slice().sort((a,b) => a.startSlot - b.startSlot);
 
                 dayShifts.forEach(shift => {
                     hasShifts = true;
@@ -144,7 +193,7 @@ export const StatsManager = {
                     const end = SLOTS[shift.endSlot + 1] ? SLOTS[shift.endSlot + 1].label : "02:00";
 
                     const tr = create("tr");
-                    tr.appendChild(create("td", { textContent: daysMap[i] }));
+                    tr.appendChild(create("td", { textContent: entry.label }));
                     tr.appendChild(create("td", { textContent: `${start} - ${end}` }));
                     tr.appendChild(create("td", { textContent: shift.role })); // create handles text content safely
 
@@ -153,14 +202,14 @@ export const StatsManager = {
                         className: "btn small secondary btn-go-shift",
                         textContent: "Ir",
                         style: { padding: "1px 4px", fontSize: "10px" },
-                        dataset: { shiftId: shift.id, day: i }
+                        dataset: { shiftId: shift.id, day: entry.dayIndex, date: entry.key || '' }
                     });
                     actionTd.appendChild(btn);
                     tr.appendChild(actionTd);
 
                     tbody.appendChild(tr);
                 });
-            }
+            });
 
             if (!hasShifts) {
                 const tr = create("tr");
@@ -207,6 +256,11 @@ export const StatsManager = {
                                     el("#weekly-summary-modal").style.display = "none";
 
                                     // Navigate logic
+                                    if (isMonthlyMode && btn.dataset.date) {
+                                        const monthInput = el("#monthly-top-month");
+                                        if (monthInput) monthInput.value = btn.dataset.date.slice(0, 7);
+                                        ScheduleManager.monthlySelectedMonth = btn.dataset.date.slice(0, 7);
+                                    }
                                     store.setState({ activeDay: day });
                                     el("#btn-view-schedule").click(); // Switch view
 

--- a/src/services/DataManager.js
+++ b/src/services/DataManager.js
@@ -251,6 +251,19 @@ export const DataManager = {
         }
     },
 
+    async saveWeek(weekId) {
+        const state = store.getState();
+        const storeId = state.activeStoreId;
+        if (!storeId || !weekId) return;
+        const weeksRef = storeWeeksRef(storeId);
+        try {
+            await weeksRef.doc(weekId).set(state.schedules[weekId] || {});
+        } catch (error) {
+            console.error("Error guardando semana:", error);
+            showToast("Error guardando semana: " + error.message, "error");
+        }
+    },
+
     async loadWeek(weekId) {
         const db = getDb();
         const state = store.getState();

--- a/src/services/DataManager.js
+++ b/src/services/DataManager.js
@@ -134,6 +134,7 @@ export const DataManager = {
                 newState.projectedTickets = data.projectedTickets || {};
                 newState.storeName = (storeRootSnap.data()?.displayName || data.storeName || storeId || '').trim();
                 newState.schedulingRules = normalizeSchedulingRules(data.schedulingRules || {});
+                newState.schedulingPeriodWeeks = [1, 2, 4].includes(Number(data.schedulingPeriodWeeks)) ? Number(data.schedulingPeriodWeeks) : 1;
 
                 // Initialize active week
                 if (!newState.activeWeek) {
@@ -177,6 +178,7 @@ export const DataManager = {
                  newState.roles = [...ROLES];
                  newState.storeName = (storeRootSnap.data()?.displayName || storeId || '').trim();
                  newState.schedulingRules = normalizeSchedulingRules();
+                 newState.schedulingPeriodWeeks = 1;
             }
 
             store.setState(newState);
@@ -221,6 +223,7 @@ export const DataManager = {
                 roles: state.roles && state.roles.length ? state.roles : ROLES,
                 storeName: (state.storeName || storeId || '').trim(),
                 schedulingRules: normalizeSchedulingRules(state.schedulingRules || {}),
+                schedulingPeriodWeeks: [1, 2, 4].includes(Number(state.schedulingPeriodWeeks)) ? Number(state.schedulingPeriodWeeks) : 1,
             };
             await Promise.all([
                 schedulesRef.doc("main").set(mainData, { merge: true }),

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -63,6 +63,7 @@ const defaultState = {
     roles: [...ROLES],
     storeName: '',
     schedulingRules: null,
+    schedulingPeriodWeeks: 1,
     // Data loaded flags
     isLoading: true,
 };

--- a/style.css
+++ b/style.css
@@ -1444,7 +1444,7 @@ body.dark-mode .monthly-grid-table tbody tr + tr td {
 
 #monthly-planner-editor {
   position: sticky;
-  top: 56px;
+  top: 0;
   z-index: 20;
   background: var(--card);
   padding: 8px;

--- a/style.css
+++ b/style.css
@@ -1345,6 +1345,50 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
   opacity: 0.3;
 }
 
+.monthly-grid-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.monthly-grid-table th,
+.monthly-grid-table td {
+  border: 1px solid var(--line);
+  text-align: center;
+  padding: 4px;
+}
+
+.monthly-grid-table th {
+  background: var(--chip);
+}
+
+.monthly-employee-cell {
+  min-width: 220px;
+  text-align: left;
+  font-weight: 600;
+  background: var(--panel);
+}
+
+.monthly-shift-cell {
+  min-width: 74px;
+  cursor: pointer;
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.monthly-shift-cell.off {
+  background: #d1d5db;
+}
+
+.monthly-shift-cell.active {
+  font-weight: 700;
+}
+
+.monthly-shift-cell.selected {
+  outline: 2px solid var(--c-primary);
+  outline-offset: -2px;
+}
+
 .danger-text td {
   color: #b91c1c !important;
   font-style: italic;

--- a/style.css
+++ b/style.css
@@ -190,8 +190,10 @@
 .slot.unassigned { opacity: 0.6; }
 
 .legend-footer {
-  position: sticky;
+  position: fixed;
   bottom: 0;
+  left: 0;
+  right: 0;
   background: #ffffffcc;
   backdrop-filter: saturate(1.1) blur(6px);
   border-top: 1px solid var(--border);
@@ -1360,6 +1362,9 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
 
 .monthly-grid-table th {
   background: var(--chip);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .monthly-employee-cell {
@@ -1367,6 +1372,9 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
   text-align: left;
   font-weight: 600;
   background: var(--panel);
+  position: sticky;
+  left: 0;
+  z-index: 11;
 }
 
 .monthly-shift-cell {
@@ -1385,8 +1393,63 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
 }
 
 .monthly-shift-cell.selected {
-  outline: 2px solid var(--c-primary);
+  outline: 2px solid #22d3ee;
   outline-offset: -2px;
+  box-shadow: inset 0 0 0 2px #111827;
+}
+
+body.dark-mode .monthly-shift-cell.selected {
+  outline: 2px solid #facc15;
+  box-shadow: inset 0 0 0 2px #f8fafc;
+}
+
+.monthly-grid-table tbody tr + tr td {
+  border-top: 3px solid #cbd5e1;
+}
+
+body.dark-mode .monthly-grid-table tbody tr + tr td {
+  border-top-color: #334155;
+}
+
+#monthly-planner-editor {
+  position: sticky;
+  top: 56px;
+  z-index: 20;
+  background: var(--card);
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+#monthly-planner-grid {
+  max-height: calc(100vh - 280px);
+  overflow: auto;
+}
+
+.monthly-context-menu {
+  position: fixed;
+  z-index: 3000;
+  min-width: 140px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+  padding: 6px;
+}
+
+.monthly-context-menu button {
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.monthly-context-menu button:hover {
+  background: var(--chip);
 }
 
 .danger-text td {

--- a/style.css
+++ b/style.css
@@ -1349,39 +1349,60 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
 
 .monthly-grid-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 2px;
   font-size: 11px;
+  background: var(--line);
 }
 
 .monthly-grid-table th,
 .monthly-grid-table td {
-  border: 1px solid var(--line);
+  border: 1px solid #94a3b8;
   text-align: center;
-  padding: 4px;
+  padding: 2px;
 }
 
 .monthly-grid-table th {
   background: var(--chip);
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 25;
 }
 
 .monthly-employee-cell {
+  width: 220px;
   min-width: 220px;
+  max-width: 220px;
   text-align: left;
   font-weight: 600;
   background: var(--panel);
   position: sticky;
   left: 0;
-  z-index: 11;
+  z-index: 20;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.monthly-grid-table thead .monthly-employee-cell {
+  z-index: 30;
 }
 
 .monthly-shift-cell {
-  min-width: 74px;
+  width: 72px;
+  min-width: 72px;
+  max-width: 72px;
+  height: 62px;
   cursor: pointer;
   background: #e5e7eb;
   color: #111827;
+  box-sizing: border-box;
+  vertical-align: middle;
+  overflow: hidden;
+}
+
+.monthly-shift-cell > div {
+  line-height: 1.05;
 }
 
 .monthly-shift-cell.off {
@@ -1404,7 +1425,7 @@ body.dark-mode .monthly-shift-cell.selected {
 }
 
 .monthly-grid-table tbody tr + tr td {
-  border-top: 3px solid #cbd5e1;
+  border-top: 2px solid #64748b;
 }
 
 body.dark-mode .monthly-grid-table tbody tr + tr td {
@@ -1424,6 +1445,7 @@ body.dark-mode .monthly-grid-table tbody tr + tr td {
 #monthly-planner-grid {
   max-height: calc(100vh - 280px);
   overflow: auto;
+  padding-bottom: 70px;
 }
 
 .monthly-context-menu {

--- a/style.css
+++ b/style.css
@@ -1349,24 +1349,28 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
 
 .monthly-grid-table {
   width: 100%;
-  border-collapse: separate;
-  border-spacing: 2px;
+  border-collapse: collapse;
   font-size: 11px;
-  background: var(--line);
+  background: var(--card);
 }
 
 .monthly-grid-table th,
 .monthly-grid-table td {
-  border: 1px solid #94a3b8;
+  border: 1px solid #64748b;
   text-align: center;
   padding: 2px;
+  overflow: hidden;
 }
 
 .monthly-grid-table th {
-  background: var(--chip);
+  background-color: #e2e8f0;
   position: sticky;
   top: 0;
   z-index: 25;
+}
+
+body.dark-mode .monthly-grid-table th {
+  background-color: #1f2937;
 }
 
 .monthly-employee-cell {
@@ -1375,17 +1379,23 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
   max-width: 220px;
   text-align: left;
   font-weight: 600;
-  background: var(--panel);
+  background-color: #f1f5f9;
   position: sticky;
   left: 0;
   z-index: 20;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  box-shadow: 2px 0 0 #64748b;
+}
+
+body.dark-mode .monthly-employee-cell {
+  background-color: #111827;
 }
 
 .monthly-grid-table thead .monthly-employee-cell {
   z-index: 30;
+  left: 0;
 }
 
 .monthly-shift-cell {
@@ -1394,7 +1404,7 @@ body.dark-mode #calendar-grid .day.monday:not(.other-month):hover {
   max-width: 72px;
   height: 62px;
   cursor: pointer;
-  background: #e5e7eb;
+  background-color: #e5e7eb;
   color: #111827;
   box-sizing: border-box;
   vertical-align: middle;
@@ -1425,7 +1435,7 @@ body.dark-mode .monthly-shift-cell.selected {
 }
 
 .monthly-grid-table tbody tr + tr td {
-  border-top: 2px solid #64748b;
+  border-top: 2px solid #475569;
 }
 
 body.dark-mode .monthly-grid-table tbody tr + tr td {


### PR DESCRIPTION
### Motivation
- Permitir que cada local elija la metodología de planificación para generar y pasar horarios en periodos de 7, 14 o 28 días sin romper la experiencia existente.
- Facilitar al manager crear/visualizar/imprimir el período completo (semana/quincena/mes de 28 días) de forma rápida y coherente.
- Mantener compatibilidad con datos existentes usando un fallback a planificación semanal si no hay preferencia guardada.

### Description
- Se agregó un selector en la pantalla de configuración del local (`manager.html`) para elegir la metodología `Semanal (7) / Quincenal (14) / Mensual (28)`. 
- `OptionsManager` ahora lee, valida y guarda la preferencia `schedulingPeriodWeeks` (valores permitidos `1`, `2`, `4`) cuando se guardan las opciones del local. 
- `DataManager` persiste `schedulingPeriodWeeks` en `schedules/main` al guardar el estado y lo restaura al cargar, con fallback a `1` (semanal) cuando no exista. 
- Se añadió `schedulingPeriodWeeks` al estado por defecto en `Store` (`schedulingPeriodWeeks: 1`).
- `ScheduleManager` se adaptó para manejar períodos multi-semana: se añadieron helpers (`getSchedulingPeriodWeeks`, `getSchedulingPeriodDays`, `getWeekIdByDayOffset`, `getDayIndexByOffset`, `getShiftsByDayOffset`) y precarga de semanas del período (`preloadPeriodWeeks`).
- Navegación de período (`prev` / `next`) ahora avanza/retrocede según la metodología seleccionada y la cabecera (`week-display`) muestra el rango completo del período; las estadísticas agregan horas/tickets/productividad sobre todo el período.
- La impresión de horarios (`printSchedule`) genera dinámicamente columnas por cada día del período (7/14/28) y muestra fechas por columna.
- Validaciones: el selector solo acepta `1`, `2` o `4` y muestra mensaje si se intenta guardar otro valor.

### Testing
- Ejecuté comprobaciones estáticas con `node --check` en `src/modules/ScheduleManager.js`, `src/modules/OptionsManager.js`, `src/services/DataManager.js` y `src/store/Store.js`, todas sin errores (pasaron correctamente). 
- Verifiqué que el repositorio no quedó con archivos pendientes de edición (`git status` mostró los cambios preparados y confirmados en la rama de trabajo). 
- No se ejecutaron tests de UI automáticos en navegador; las modificaciones fueron diseñadas para mantener el comportamiento existente en rutas no afectadas y usan fallback seguro a semanal cuando no hay preferencia guardada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cece0b6f9c832d957699660ecd25a5)